### PR TITLE
Added dropdownlist filter type and Material Design "chip" styling.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -111,6 +111,21 @@
         ]
       },
       {
+        type: 'dropdownlist',
+        label: 'State',
+        key: 'state',
+        options: {
+          type: 'typeahead' // normally defaults to 'dropdown', other valid options are 'combobox'
+        },
+        values: [
+          {label:'California', value:'California'},
+          {label:'Florida', value:'Florida'},
+          {label:'Nevada', value:'Nevada'},
+          {label:'New York', value:'New York'},
+          {label:'Texas', value:'Texas'}
+        ]
+      },
+      {
         type: 'dropdown',
         label: 'Sales Rep',
         key: 'rep',

--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -13,59 +13,71 @@ Header bar Polymer element for doing filters / faceted search.
 <dom-module id="radium-filter-bar">
   <style is="custom-style">
     .filterbar {
-      background-color: #DDDDDD;
+      background-color: #F5F5F5;
       color: rgba(0, 0, 0, 0.87);
       line-height: 40px;
-      padding: 0px 24px;
+      padding: 4px 16px;
     }
-    .filterbar-title {
-      margin: 0px 16px 0px 0px;
+    .filterbar div {
+      margin-right: 8px;
     }
-    .filterbar paper-button {
-      margin: 0px 8px 0px 0px;
-      min-width: initial;
-      text-transform: none;
-      white-space: nowrap;
+    .filterbar div:last-child {
+      margin-right: 0;
     }
-    .filterbar a {
-      text-align:right;
+    #clearIcon {
       cursor: pointer;
     }
     .filterbar paper-button {
-      padding: 0px;
+      display: inline-block;
+      box-sizing: border-box;
+      padding: 0 6px 0 12px;
+      margin: 0px 4px 0px 0px;
+      min-width: initial;
+      height: 32px;
+      line-height: 32px;
+      text-transform: none;
+      white-space: nowrap;
+      cursor: pointer;
+      background-color: #E0E0E0;
+      border-radius: 16px;
     }
     .filterbar paper-button > ::content paper-material {
       padding: 0px;
     }
-    .filterbar iron-icon {
-      color: #ff0000;
-      width: 14px;
-      height: 14px;
-      margin: 2px 0px 0px 0px;
+    .filterbar paper-button .chip-label {
+      font-size: 14px;
+      font-weight: 400;
     }
-    .typo-body2 {
-      font-size: 14px !important;
-      font-weight: 500 !important;
+    .filterbar paper-button iron-icon {
+      color: #9E9E9E;
+      width: 20px;
+      height: 20px;
+      margin-top: -2px;
     }
-    .typo-body1 {
-      font-size: 14px !important;
-      font-weight: 400 !important;
+    .filterbar paper-button:hover {
+      color: #ffffff;
+      background-color: #616161;
+    }
+    .filterbar paper-button:hover iron-icon {
+      color: #ffffff;
     }
   </style>
   <template>
     <div class="filterbar horizontal layout">
-      <div class="filterbar-title typo-body2">Filtered By:</div>
+      <div hidden$="[[!showFilterIcon]]">
+        <iron-icon icon="filter-list"></iron-icon>
+      </div>
       <div class="flex">
         <template is="dom-repeat" items="[[_getChipsForFiltersAndTerms(filters, terms)]]">
-          <paper-button on-click="_termClicked" data-term$="[[item]]">
-            <span class="typo-body1">[[item.label]]</span>
-            <iron-icon icon="close"></iron-icon>
+          <paper-button data-term$="[[item]]" on-click="_termClicked">
+            <span class="chip-label">[[item.label]]</span>
+            <iron-icon icon="cancel"></iron-icon>
           </paper-button>
         </template>
       </div>
-      <a on-click="_clearAllClicked">
-        <span class="typo-body1">Clear All</span>
-      </a>
+      <div>
+        <iron-icon id="clearIcon" icon="clear" on-click="_clearAllClicked"></iron-icon>
+      </div>
     </div>
   </template>
 </dom-module>
@@ -75,6 +87,13 @@ Header bar Polymer element for doing filters / faceted search.
       is: 'radium-filter-bar',
 
       behaviors: [RadiumFilterBehavior],
+
+      properties: {
+        showFilterIcon: {
+          type: Boolean,
+          value: true
+        }
+      },
 
       _getChipsForFiltersAndTerms: function() {
         return this.terms.map(function(term){

--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -64,7 +64,7 @@ Header bar Polymer element for doing filters / faceted search.
   </style>
   <template>
     <div class="filterbar horizontal layout">
-      <div hidden$="[[!showFilterIcon]]">
+      <div hidden$="[[hideFilterIcon]]">
         <iron-icon icon="filter-list"></iron-icon>
       </div>
       <div class="flex">
@@ -89,9 +89,9 @@ Header bar Polymer element for doing filters / faceted search.
       behaviors: [RadiumFilterBehavior],
 
       properties: {
-        showFilterIcon: {
+        hideFilterIcon: {
           type: Boolean,
-          value: true
+          value: false
         }
       },
 

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -134,6 +134,26 @@
     },
 
     /**
+     * Finds the term corresponding to the specified filter key and value (if present).
+     *
+     * @param {string} key
+     * @param {number|string} value
+     * @returns {Array<FilterTerm>|undefined}
+     */
+    findTerms: function(key, value) {
+      if (value !== undefined) {
+        return (this.terms || []).filter(function(term) {
+          return (term.key === key && term.value === value);
+        });
+      }
+      else {
+        return (this.terms || []).filter(function(term) {
+          return (term.key === key);
+        });
+      }
+    },
+
+    /**
      * Replaces (or adds) a term for the specified filter key and value.
      *
      * @param {string} key

--- a/radium-filter-dropdown-list.html
+++ b/radium-filter-dropdown-list.html
@@ -1,0 +1,138 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
+<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../radium-combo/radium-combo.html">
+<!--
+Dropdown list filter component.
+
+@element radium-filter-dropdown-list
+@demo demo/index.html Basic demo
+-->
+<dom-module id="radium-filter-dropdown-list">
+  <style is="custom-style">
+    .dropdown-list {
+
+    }
+
+    .value-row {
+      margin: 4px 0;
+      line-height: 20px;
+    }
+
+    .value-row .value-label {
+      display: inline-flex;
+      width: calc(100% - 24px);
+      font-size: 14px;
+      font-weight: 400;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      vertical-align: middle;
+    }
+
+    .value-row iron-icon {
+      width: 18px;
+      height: 18px;
+      vertical-align: middle;
+      cursor: pointer;
+    }
+
+    #combo {
+
+    }
+  </style>
+  <template>
+    <div class="dropdown-list vertical layout">
+      <div class="flex">
+        <template is="dom-repeat" items="[[value]]">
+          <div class="value-row">
+            <div class="value-label">[[_getOptionLabelForValue(options, item)]]</div>
+            <iron-icon icon="cancel" on-tap="_removeValueClick"></iron-icon>
+          </div>
+        </template>
+      </div>
+      <radium-combo id="combo" type="[[type]]" options="[[_getFilteredListOptions(options, value)]]" include-empty="false" no-label-float on-option-change="_optionChange"></radium-combo>
+    </div>
+  </template>
+</dom-module>
+<script>
+  (function() {
+    Polymer({
+      is: 'radium-filter-dropdown-list',
+
+      properties: {
+        options: {
+          type: Array,
+          value: function() {
+            return [];
+          }
+        },
+        /**
+         * The type of selection control
+         * Choices are:
+         *    dropdown
+         *    typeahead
+         *    combobox
+         */
+        type: {
+          type: String,
+          value: 'dropdown'
+        },
+        value: {
+          type: Array,
+          value: function() {
+            return [];
+          },
+          observer: '_valueChanged'
+        }
+      },
+
+      ready: function() {
+        this.$.combo.value = '';
+      },
+
+      _getFilteredListOptions: function(options, selected) {
+        options = options || [];
+        if (selected && selected.length > 0) {
+          return options.filter(function(option) {
+            return selected.indexOf(option.value) === -1;
+          });
+        }
+        return options;
+      },
+
+      _getOptionLabelForValue: function(options, value) {
+        var option = (options || []).find(function(option) {
+          return option.value === value;
+        });
+        return (option && option.label) ? option.label : value;
+      },
+
+      _valueChanged: function(e) {
+        this.$.combo.value = '';
+      },
+
+      _optionChange: function(e) {
+        var option = e.detail;
+
+        if (option.label || option.value) {
+          var value = option.value || option.label;
+
+          this.value = (this.value || []).concat(value);
+          this.fire('value-added', { value: value });
+        }
+      },
+
+      _removeValueClick: function(e) {
+        var valueToRemove = e.model.__data__.item;
+
+        this.value = (this.value || []).filter(function(value) {
+          return value !== valueToRemove;
+        });
+        this.fire('value-removed', { value: valueToRemove });
+      }
+
+    });
+  })();
+</script>

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../radium-combo/radium-combo.html">
 <link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="radium-filter-dropdown-list.html">
 <link rel="import" href="radium-filter-behavior.html">
 <!--
 Side Panel Polymer element for doing filters / faceted search.
@@ -119,6 +120,10 @@ Side Panel Polymer element for doing filters / faceted search.
               }.bind(this));
               break;
 
+            case 'dropdownlist':
+              collapse.appendChild(this._createDropdownListControl(filter));
+              break;
+
             default:
               console.warn('Unknown filter control type: ' + filter.type);
               break;
@@ -137,13 +142,16 @@ Side Panel Polymer element for doing filters / faceted search.
         controls.forEach(function (control) {
           var key = control.getAttribute('data-filter-key');
           var value = control.getAttribute('data-filter-value') || undefined;
-          var term = this.findTerm(key, value);
-          if (term) {
+          var terms = this.findTerms(key, value);
+          if (terms.length > 0) {
             if (value !== undefined) {
               this._setControlSelected(control);
             }
             else {
-              this._setControlValue(control, term.value);
+              var values = terms.map(function(term) {
+                return term.value;
+              });
+              this._setControlValues(control, values);
             }
           }
           else {
@@ -198,6 +206,16 @@ Side Panel Polymer element for doing filters / faceted search.
         return dropdown;
       },
 
+      _createDropdownListControl: function(filter) {
+        var dropdownList = document.createElement('radium-filter-dropdown-list');
+        dropdownList.setAttribute('data-filter-key', filter.key);
+        dropdownList.options = filter.values;
+        this._applyOptions(dropdownList, filter.options || {});
+        dropdownList.addEventListener('value-added', this._dropdownListValueAdded.bind(this));
+        dropdownList.addEventListener('value-removed', this._dropdownListValueRemoved.bind(this));
+        return dropdownList;
+      },
+
       _setControlSelected: function(control) {
         switch (control.nodeName.toLowerCase()) {
           case 'paper-checkbox':
@@ -209,13 +227,16 @@ Side Panel Polymer element for doing filters / faceted search.
         }
       },
 
-      _setControlValue: function(control, value) {
+      _setControlValues: function(control, values) {
         switch (control.nodeName.toLowerCase()) {
           case 'paper-input':
-            control.value = value;
+            control.value = values[0] || '';
             break;
           case 'radium-combo':
-            control.setValue(value);
+            control.setValue(values[0] || '');
+            break;
+          case 'radium-filter-dropdown-list':
+            control.value = values;
             break;
           default:
             console.warn("Unknown filter node: " + control.nodeName.toLowerCase());
@@ -233,6 +254,9 @@ Side Panel Polymer element for doing filters / faceted search.
             break;
           case 'radium-combo':
             control.clearSelection();
+            break;
+          case 'radium-filter-dropdown-list':
+            control.value = [];
             break;
           default:
             console.warn("Unknown filter node: " + control.nodeName.toLowerCase());
@@ -274,6 +298,18 @@ Side Panel Polymer element for doing filters / faceted search.
         else {
           this.removeTerm(key);
         }
+      },
+
+      _dropdownListValueAdded: function(e) {
+        var key = e.currentTarget.getAttribute('data-filter-key');
+        var value = e.detail.value;
+        this.addTerm(key, value);
+      },
+
+      _dropdownListValueRemoved: function(e) {
+        var key = e.currentTarget.getAttribute('data-filter-key');
+        var value = e.detail.value;
+        this.removeTerm(key, value);
       },
 
       _filtersChanged: function() {


### PR DESCRIPTION
### Styling changes:
- Styled filter bar and facets buttons to match Material Design filter chips.
  - See: https://www.google.com/design/spec/components/chips.html#chips-behavior
### Added new `dropdownlist` filter type:
- Added new `dropdownlist` filter type to `radium-filter-panel`.
  - Provides an alternative to the `checkboxlist` for picking from larger sets of options.
  - Implemented via new `radium-filter-dropdown-list` component.
    - Presents a list of selected values (with their label derived from supplied options), where each list item has an associated "remove" button to deselect that item.
    - Presents a `radium-combobox` below that list for selecting more values from a set of options (filtering out options that were already selected).
      - That combobox defaults to a dropdown, but can be configured to be a typeahead or combobox (even allowing the addition of arbitrary new values).
- Updated demo to show an example `dropdownlist` filter (configured with the same filter values as the existing `checklist` filter).

![radium-filters-enhancements](https://cloud.githubusercontent.com/assets/140385/14190152/41e89b10-f75f-11e5-8cd9-28f49209e10a.gif)
