### PR TITLE
Added support for (optionally) including the filter label in the filter bar chips.

### DIFF
--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -63,6 +63,9 @@ Header bar Polymer element for doing filters / faceted search.
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .filterbar paper-button .chip-label .filter-label {
+      font-weight: 500;
+    }
     .filterbar paper-button iron-icon {
       color: #9E9E9E;
       width: 20px;
@@ -96,7 +99,10 @@ Header bar Polymer element for doing filters / faceted search.
           <template is="dom-repeat" items="[[_getChipsForFiltersAndTerms(filters, terms)]]">
             <paper-button data-term$="[[item]]" on-click="_termClicked">
               <div class="chip-label-container">
-                <span class="chip-label">[[item.label]]</span>
+                <span class="chip-label">
+                  <span class="filter-label" hidden$="[[hideFilterLabel]]">[[item.filterLabel]]:</span>
+                  <span class="term-label">[[item.label]]</span>
+                </span>
               </div>
               <iron-icon icon="cancel"></iron-icon>
             </paper-button>
@@ -117,6 +123,10 @@ Header bar Polymer element for doing filters / faceted search.
       behaviors: [RadiumFilterBehavior],
 
       properties: {
+        hideFilterLabel: {
+          type: Boolean,
+          value: false
+        },
         hideFilterIcon: {
           type: Boolean,
           value: false
@@ -126,6 +136,7 @@ Header bar Polymer element for doing filters / faceted search.
       _getChipsForFiltersAndTerms: function() {
         return this.terms.map(function(term){
           return {
+            filterLabel: this.getFilterLabelForTerm(term),
             label: this.getLabelForTerm(term),
             key: term.key,
             value: term.value

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -87,6 +87,20 @@
     },
 
     /**
+     * Gets the filter label that corresponds to the specified term (if available), or returns an empty string.
+     *
+     * @param {FilterTerm} term
+     * @returns {number|string}
+     */
+    getFilterLabelForTerm: function(term) {
+      var filter = this.getFilterForTerm(term);
+      if (filter) {
+        return filter.label;
+      }
+      return '';
+    },
+
+    /**
      * Gets the label that corresponds to the specified term (if available), or returns the term value.
      *
      * @param {FilterTerm} term


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/140385/17526512/8dde0090-5e35-11e6-820f-720104640af6.png)

After:

![after](https://cloud.githubusercontent.com/assets/140385/17526517/8f871f8a-5e35-11e6-9ce9-c00de6f7fe39.png)

Configured via new `hideFilterLabel` property.
