### PR TITLE
Fix to allow selecting falsy values in dropdown-list type filter.

### DIFF
--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -31,7 +31,7 @@ Header bar Polymer element for doing filters / faceted search.
       max-height: 100px;
       overflow-y: auto;
     }
-    #clearIcon {
+    #clearAllIcon {
       cursor: pointer;
     }
     .filterbar paper-button {
@@ -130,7 +130,7 @@ Header bar Polymer element for doing filters / faceted search.
           </div>
         </div>
         <div>
-          <iron-icon id="clearIcon" icon="clear" on-click="_clearAllClicked"></iron-icon>
+          <iron-icon id="clearAllIcon" icon="clear" hidden$="[[hideClearAllButton]]" on-click="_clearAllClicked"></iron-icon>
         </div>
       </template>
     </div>
@@ -144,6 +144,15 @@ Header bar Polymer element for doing filters / faceted search.
       behaviors: [RadiumFilterBehavior],
 
       properties: {
+        /**
+         * Set to true to hide the clear all button.
+         *
+         * @type boolean
+         */
+        hideClearAllButton: {
+          type: Boolean,
+          value: false
+        },
         /**
          * Set to true to hide the filter label.
          *

--- a/radium-filter-dropdown-list.html
+++ b/radium-filter-dropdown-list.html
@@ -108,8 +108,8 @@ Dropdown list filter component.
       _optionChange: function(e) {
         var option = e.detail;
 
-        if (option.label || option.value) {
-          var value = option.value || option.label;
+        if (option.value !== undefined || option.label) {
+          var value = (option.value !== undefined) ? option.value : option.label;
 
           this.value = (this.value || []).concat(value);
           this.fire('value-added', { value: value });


### PR DESCRIPTION
When I added the `dropdown-list` filter type, I accidentally introduced a bad conditional here - we should compare specifically against `undefined` when determining whether to fall back to the label as the selected value. The existing condition does not support valid defined values that evaluate to `false` in JavaScript (such as `0` or `‘’`).
