### PR TITLE
Subtle event listener tweak to avoid unnecessary terms-changed events

### DIFF
--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -429,7 +429,7 @@ Side Panel Polymer element for doing filters / faceted search.
       _inputChanged: function(e) {
         var wait = parseInt(e.currentTarget.getAttribute('data-debounce-wait'));
         var key = e.currentTarget.getAttribute('data-filter-key');
-        var value = e.detail.value;
+        var value = e.currentTarget.value;
         this.debounce('input', function() {
           if (value && value !== null && value !== '') {
             this.replaceTerm(key, value);

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -297,7 +297,7 @@ Side Panel Polymer element for doing filters / faceted search.
         input.setAttribute('data-filter-key', filter.key);
         input.setAttribute('data-debounce-wait', filter.debounce || 350);
         this._applyOptions(input, filter.options || {});
-        input.addEventListener('change', this._inputChanged.bind(this));
+        input.addEventListener('keyup', this._inputChanged.bind(this));
         return input;
       },
 
@@ -427,10 +427,11 @@ Side Panel Polymer element for doing filters / faceted search.
       },
 
       _inputChanged: function(e) {
-        var wait = parseInt(e.currentTarget.getAttribute('data-debounce-wait'));
-        var key = e.currentTarget.getAttribute('data-filter-key');
-        var value = e.currentTarget.value;
+        var input = e.currentTarget;
+        var wait = parseInt(input.getAttribute('data-debounce-wait'));
+        var key = input.getAttribute('data-filter-key');
         this.debounce('input', function() {
+          var value = input.value;
           if (value && value !== null && value !== '') {
             this.replaceTerm(key, value);
           }

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -297,7 +297,7 @@ Side Panel Polymer element for doing filters / faceted search.
         input.setAttribute('data-filter-key', filter.key);
         input.setAttribute('data-debounce-wait', filter.debounce || 350);
         this._applyOptions(input, filter.options || {});
-        input.addEventListener('value-changed', this._inputChanged.bind(this));
+        input.addEventListener('change', this._inputChanged.bind(this));
         return input;
       },
 


### PR DESCRIPTION
The input control was triggering events during its initialization that subsequently triggered extra (inaccurate) events notifying `<radium-filter-panel>` listeners that the terms had changed.

This caused our application to think the user had changed the filter criteria when they actually hadn’t. This meant we incorrectly marked our saved filters as dirty and triggered unnecessary extra service calls.

In `radium-filter-panel::_createInputControl()`, it creates a `<paper-input>` and listens for `value-changed`. That event fires whenever the value changes, including when the value is set programmatically. However, we’re only interested in when the user makes changes to the value.

I switched this to listen to `change` instead. From the Polymer docs for `<paper-input>`:

> change - Fired when the input changes due to user interaction.

Now this behaves like the listeners used for the other filter control types, and only triggering in response to a user gesture.
