### PR TITLE
Added support for min-length=“0“ for autocomplete and autocomplete-list

### DIFF
--- a/radium-filter-autocomplete-list.html
+++ b/radium-filter-autocomplete-list.html
@@ -63,6 +63,11 @@ Autocomplete list filter component.
             return [];
           }
         },
+        minLength: {
+          type: Number,
+          value: 1,
+          observer: '_minLengthChanged'
+        },
         source: {
           type: Function,
           value: null
@@ -108,6 +113,10 @@ Autocomplete list filter component.
           return filterValue.value === value;
         });
         return (filterValue && filterValue.label) ? filterValue.label : value;
+      },
+
+      _minLengthChanged: function(e) {
+        this.$.autocomplete.minLength = this.minLength;
       },
 
       _valueChanged: function (e) {

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -213,7 +213,7 @@ Dropdown list filter autocomplete component..
       },
 
       executeQuery: function(query) {
-        if (query && query.length >= this.minLength && this.source) {
+        if (query !== null && query !== undefined && query.length >= this.minLength && this.source) {
           this.value = query;
           this._loading = true;
           this._suggestions = [];


### PR DESCRIPTION
Previously, only `min-length` values > 0 were supported.
- Modified `radium-filter-autocomplete::executeQuery()` to support a `minLength` value of zero.
- Modified `radium-filter-autocomplete-list` to add a `minLength` property which passes that value through to its child `radium-filter-autocomplete` instance.
