### PR TITLE
Added “clear” event to disambiguate between changes and clearing an autocomplete.

### DIFF
--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -258,12 +258,14 @@ Dropdown list filter autocomplete component..
         this.cancelDebouncer('input');
         this._isDirty = false;
         this.fire('change');
+        this.fire('clear');
       },
 
       _onClearIconTap: function() {
         this.value = '';
         this.cancelDebouncer('input');
         this.fire('change');
+        this.fire('clear');
       },
 
       _onDropdownIronOverlayClosed: function() {


### PR DESCRIPTION
When the `radium-filter-autocomplete` is cleared, it dispatches a `change` event (just like if the field is otherwise edited via typing).

We are using the `radium-filter-autocomplete` component in a standalone manner within a form in our application, and need to know when the user specifically _cleared_ the UI (either via the clear button or failing to autocomplete to an available suggestion).

Added logic to additionally fire `clear` events for these operations.
