### PR TITLE
Added dropdown item label truncation to radium-filter-autocomplete.

### DIFF
--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -67,6 +67,12 @@ Dropdown list filter autocomplete component..
       height: 64px;
     }
 
+    paper-item span {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow-x: hidden;
+    }
+
     paper-spinner {
       --paper-spinner-layer-1-color: var(--radium-filter-loading-spinner-color, #0072BC);
       --paper-spinner-layer-2-color: var(--radium-filter-loading-spinner-color, #0072BC);


### PR DESCRIPTION
Mirrored dropdown item label truncation styles from `<radium-combo>` to `<radium-filter-autocomplete>`.
