### PR TITLE
Added optional data field for autocomplete filter values.

### DIFF
--- a/radium-filter-autocomplete-list.html
+++ b/radium-filter-autocomplete-list.html
@@ -128,7 +128,7 @@ Autocomplete list filter component.
 
         if (suggestion.label && suggestion.value) {
           this.value = (this.value || []).concat(suggestion.value);
-          this.fire('value-added', {label: suggestion.label, value: suggestion.value});
+          this.fire('value-added', { label: suggestion.label, value: suggestion.value, data: suggestion.data });
         }
       },
 
@@ -138,7 +138,7 @@ Autocomplete list filter component.
         this.value = (this.value || []).filter(function (value) {
           return value !== valueToRemove;
         });
-        this.fire('value-removed', {value: valueToRemove});
+        this.fire('value-removed', { value: valueToRemove });
       }
 
     });

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -4,7 +4,8 @@
    *
    * @typedef {(
    *  label: (string),
-   *  value: (number|string)
+   *  value: (number|string),
+   *  data: (object)
    * )} FilterValue
    */
 
@@ -64,7 +65,7 @@
      * @param {string} label
      * @param {number|string} value
      */
-    replaceFilterValue: function(key, label, value) {
+    replaceFilterValue: function(key, label, value, data) {
       var filter = this.filters.find(function(filter) {
         return filter.key === key;
       });
@@ -73,7 +74,8 @@
           return !(filterValue.value == value);
         }).concat( {
           label: label,
-          value: value
+          value: value,
+          data: data
         });
       }
     },

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -244,14 +244,14 @@ Side Panel Polymer element for doing filters / faceted search.
                             });
                             if (suggestion) {
                               // Use the label/value returned as a suggestion as the new filter value.
-                              return {label: suggestion.label, value: suggestion.value};
+                              return {label: suggestion.label, value: suggestion.value, data: suggestion.data};
                             }
                             else {
                               // No corresponding suggestion was returned, check if we already have the filter value.
                               var filterValue = this.getFilterValueForTerm(term);
                               if (!filterValue) {
                                 // Create a new filter value, using the value as the label.
-                                return {label: term.value, value: term.value};
+                                return {label: term.value, value: term.value, data: undefined};
                               }
                               // Use the existing filter value.
                               return filterValue;
@@ -481,7 +481,8 @@ Side Panel Polymer element for doing filters / faceted search.
         var key = autocompleteList.getAttribute('data-filter-key');
         var label = e.detail.label;
         var value = e.detail.value;
-        this.replaceFilterValue(key, label, value);
+        var data = e.detail.data;
+        this.replaceFilterValue(key, label, value, data);
         this.addTerm(key, value);
       },
 


### PR DESCRIPTION
* Added an optional field to FilterValue, called `data`.
* Modified `replaceFilterValue()` to accept and propagate this optional argument in dynamically loaded FilterValues.
* Modified `radium-filter-autocomplete-list` to include `data` from selected suggestions when notifying listeners via the `value-added` event.
* Modified `radium-filter-panel` to pass that optional `data` property from `value-added` events when creating/updating dynamically loaded FilterValues via `suggestions` from the corresponding `source`.

These changes make it possible to propagate additional optional data in FilterValues retreived from dynamically loaded autocomplete suggestions.

For example, a suggestion for an Address autocomplete source might have more valuable information beyond its identifier `value`, such as individual address fields. The autocomplete source can return these as properties of a `data` object and it will be added to the resulting FilterValue that is dynamically created.