### PR TITLE
Configured autocomplete "value" property to notify: true

### DIFF
--- a/radium-filter-autocomplete-list.html
+++ b/radium-filter-autocomplete-list.html
@@ -77,6 +77,7 @@ Autocomplete list filter component.
           value: function () {
             return [];
           },
+          notify: true,
           observer: '_valueChanged'
         }
       },

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -214,7 +214,8 @@ Dropdown list filter autocomplete component..
          */
         value: {
           type: String,
-          value: null
+          value: null,
+          notify: true
         },
         /**
          * Set to true to mark the input as required.


### PR DESCRIPTION
Modified the configuration for the `value` property in `<radium-filter-autocomplete>` and `<radium-filter-autocomplete-list>` to include `notify: true` so that this property can participate in two-way binding expressions.