### PR TITLE
Updated to Polymer 1.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"
@@ -25,22 +25,18 @@
   "homepage": "https://github.com/jasongardnerlv/radium-filters",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#1.2.3",
-    "iron-collapse": "PolymerElements/iron-collapse#1.0.4",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#1.2.2",
-    "iron-icon": "PolymerElements/iron-icon#1.0.7",
-    "iron-icons": "PolymerElements/iron-icons#1.1.0",
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#1.0.2",
-    "paper-button": "PolymerElements/paper-button#1.0.10",
-    "paper-checkbox": "PolymerElements/paper-checkbox#1.0.16",
-    "paper-input": "PolymerElements/paper-input#1.1.2",
-    "paper-listbox": "PolymerElements/paper-listbox#1.1.0",
-    "paper-spinner": "PolymerElements/paper-spinner#1.1.0",
-    "radium-combo": "jasongardnerlv/radium-combo#0.6.0"
+    "polymer": "Polymer/polymer#1.7.0",
+    "iron-collapse": "PolymerElements/iron-collapse#1.3.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#1.3.1",
+    "iron-icon": "PolymerElements/iron-icon#1.0.12",
+    "iron-icons": "PolymerElements/iron-icons#1.2.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#1.0.5",
+    "paper-button": "PolymerElements/paper-button#1.0.14",
+    "paper-checkbox": "PolymerElements/paper-checkbox#1.4.2",
+    "paper-input": "PolymerElements/paper-input#1.1.22",
+    "paper-listbox": "PolymerElements/paper-listbox#1.1.2",
+    "paper-spinner": "PolymerElements/paper-spinner#1.2.1",
+    "radium-combo": "jasongardnerlv/radium-combo#v0.7.0"
   },
-  "devDependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "Polymer/web-component-tester#^3.3.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0"
-  }
+  "devDependencies": {}
 }

--- a/radium-filter-autocomplete-list.html
+++ b/radium-filter-autocomplete-list.html
@@ -42,7 +42,7 @@ Autocomplete list filter component.
             <div class="value-label" title="[[_getFilterValueLabelForValue(filterValues, item)]]">
               [[_getFilterValueLabelForValue(filterValues, item)]]
             </div>
-            <iron-icon icon="cancel" on-tap="_removeValueClick"></iron-icon>
+            <iron-icon icon="cancel" on-tap="_removeValueTap"></iron-icon>
           </div>
         </template>
       </div>
@@ -133,7 +133,9 @@ Autocomplete list filter component.
         }
       },
 
-      _removeValueClick: function (e) {
+      _removeValueTap: function (e) {
+        e.stopPropagation();
+        
         var valueToRemove = e.model.__data__.item;
 
         this.value = (this.value || []).filter(function (value) {

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -301,6 +301,8 @@ Dropdown list filter autocomplete component..
       },
 
       _onClearIconTap: function() {
+        e.stopPropagation();
+        
         this.value = '';
         this.cancelDebouncer('input');
         this.fire('change');
@@ -372,6 +374,8 @@ Dropdown list filter autocomplete component..
       },
 
       _onSuggestionItemTap: function(e) {
+        e.stopPropagation();
+        
         var selectedSuggestion = this._suggestions[e.currentTarget.value];
         this.value = selectedSuggestion.label;
         this._isDirty = false;

--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -193,11 +193,15 @@ Header bar Polymer element for doing filters / faceted search.
         }.bind(this));
       },
 
-      _clearAllClicked: function() {
+      _clearAllClicked: function(evt) {
+        evt.stopPropagation();
+        
         this.removeAllTerms();
       },
 
       _termClicked: function(evt) {
+        evt.stopPropagation();
+        
         var term = JSON.parse(evt.currentTarget.getAttribute('data-term'));
         this.removeTerm(term.key, term.value);
       }

--- a/radium-filter-dropdown-list.html
+++ b/radium-filter-dropdown-list.html
@@ -40,7 +40,7 @@ Dropdown list filter component.
         <template is="dom-repeat" items="[[value]]">
           <div class="value-row">
             <div class="value-label" title="[[_getOptionLabelForValue(options, item)]]">[[_getOptionLabelForValue(options, item)]]</div>
-            <iron-icon icon="cancel" on-tap="_removeValueClick"></iron-icon>
+            <iron-icon icon="cancel" on-tap="_removeValueTap"></iron-icon>
           </div>
         </template>
       </div>
@@ -116,7 +116,9 @@ Dropdown list filter component.
         }
       },
 
-      _removeValueClick: function(e) {
+      _removeValueTap: function(e) {
+        e.stopPropagation();
+        
         var valueToRemove = e.model.__data__.item;
 
         this.value = (this.value || []).filter(function(value) {

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -147,29 +147,29 @@ Side Panel Polymer element for doing filters / faceted search.
 
           switch (filter.type) {
             case 'input':
-              collapse.appendChild(this._createInputControl(filter));
+              Polymer.dom(collapse).appendChild(this._createInputControl(filter));
               break;
 
             case 'dropdown':
-              collapse.appendChild(this._createDropdownControl(filter));
+              Polymer.dom(collapse).appendChild(this._createDropdownControl(filter));
               break;
 
             case 'checkboxlist':
               filter.values.forEach(function(value) {
-                collapse.appendChild(this._createCheckboxListControl(filter.key, value, filter.options));
+                Polymer.dom(collapse).appendChild(this._createCheckboxListControl(filter.key, value, filter.options));
               }.bind(this));
               break;
 
             case 'autocomplete':
-              collapse.appendChild(this._createAutocompleteControl(filter));
+              Polymer.dom(collapse).appendChild(this._createAutocompleteControl(filter));
               break;
 
             case 'autocompletelist':
-              collapse.appendChild(this._createAutocompleteListControl(filter));
+              Polymer.dom(collapse).appendChild(this._createAutocompleteListControl(filter));
               break;
 
             case 'dropdownlist':
-              collapse.appendChild(this._createDropdownListControl(filter));
+              Polymer.dom(collapse).appendChild(this._createDropdownListControl(filter));
               break;
 
             default:
@@ -177,11 +177,12 @@ Side Panel Polymer element for doing filters / faceted search.
               break;
           }
 
-          filterRow.appendChild(label);
-          filterRow.appendChild(collapse);
+          Polymer.dom(filterRow).appendChild(label);
+          Polymer.dom(filterRow).appendChild(collapse);
 
-          filterContainer.appendChild(filterRow);
+          Polymer.dom(filterContainer).appendChild(filterRow);
         }.bind(this));
+        Polymer.dom.flush();
       },
 
       _populateControls: function() {
@@ -318,8 +319,8 @@ Side Panel Polymer element for doing filters / faceted search.
         label.className += 'typo-body1';
         label.innerHTML = value.label;
 
-        checklist.appendChild(checkbox);
-        checklist.appendChild(label);
+        Polymer.dom(checklist).appendChild(checkbox);
+        Polymer.dom(checklist).appendChild(label);
 
         return checklist;
       },

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -139,7 +139,9 @@ Side Panel Polymer element for doing filters / faceted search.
           collapse.id = 'filter' + filterIndex;
           collapse.setAttribute('opened', 'true');
 
-          label.addEventListener('click', function() {
+          label.addEventListener('click', function(evt) {
+            evt.stopPropagation();
+            
             collapse.toggle();
           });
 


### PR DESCRIPTION
* Bumped version to 0.0.3.
* Updated all dependencies (included Polymer) to known-good versions (similar to what was done recently for radium-datagrid).
* Added missing `e.stopPropagation()` calls to tap handlers.
    * Addresses issues caused when events bubble up to `<paper-drawer-panel>`, especially for elements that handlers in these components removed.
    * (`<paper-drawer-panel>` was throwing an runtime error: "Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'." for these events.)
* Wrapped all programatic DOM manipulation using the `Polymer.dom()` APIs.
    * This fixed an issue where manually added DOM elements were removed if this component was nested in the `<content>` of another component (for example `<paper-drawer-panel>`).