### PR TITLE
Fix for RTE caused by missing event parameter.

### DIFF
--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -300,7 +300,7 @@ Dropdown list filter autocomplete component..
         this.fire('clear');
       },
 
-      _onClearIconTap: function() {
+      _onClearIconTap: function(e) {
         e.stopPropagation();
         
         this.value = '';


### PR DESCRIPTION
Calling `e.stopPropagation()` but forgot to include `e` parameter in handler method signature.