### PR TITLE
Fix to refit() dropdown if previously fit to loading indicator’s height.

### DIFF
--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -267,6 +267,11 @@ Dropdown list filter autocomplete component..
         if (this._suggestions.length > 0) {
           this.$.listbox.select();
         }
+
+        // Trigger the dropdown to refit (after browser reflow), in case it previously fit itself for loading indicator.
+        this.async(function(){
+          this.$.dropdown.refit();
+        }, 1);
       },
 
       _openDropdown: function() {


### PR DESCRIPTION
If the autocomplete source takes long enough that the loading indicator is shown, the dropdown will be fit to the height of the loading indicator. When suggestions were subsequently applied, the dropdown was not being refit to new bounds.

This adds a call to refit() the dropdown once suggestions arrive (scheduled to occur after the browser reflow from rendering the suggestions).