### PR TITLE
Added support for custom filter controls.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"
@@ -35,6 +35,7 @@
     "paper-checkbox": "PolymerElements/paper-checkbox#1.4.2",
     "paper-input": "PolymerElements/paper-input#1.1.22",
     "paper-listbox": "PolymerElements/paper-listbox#1.1.2",
+    "paper-slider": "PolymerElements/paper-slider#1.0.12",
     "paper-spinner": "PolymerElements/paper-spinner#1.2.1",
     "radium-combo": "jasongardnerlv/radium-combo#v0.7.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,6 +7,7 @@
   <title>radium-filters demo</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
+  <link rel="import" href="../../paper-slider/paper-slider.html">
   <link rel="import" href="../radium-filter-bar.html">
   <link rel="import" href="../radium-filter-panel.html">
   <link rel="import" href="../radium-filter-autocomplete.html">
@@ -24,368 +25,383 @@
   </style>
 </head>
 <body unresolved>
-  <template is="dom-bind" id="app">
-    <radium-filter-querystring filters="[[_filters]]" terms="{{_terms}}"></radium-filter-querystring>
-    <div class="fit horizontal layout">
-      <div id="panelWrapper">
-        <radium-filter-panel id="filterpanel" filters="[[_filters]]" terms="{{_terms}}" loading="{{_loading}}"></radium-filter-panel>
-      </div>
-      <div class="flex">
-        <radium-filter-bar id="filterbar" label="Test" filters="[[_filters]]" terms="{{_terms}}" loading="{{_loading}}"></radium-filter-bar>
-        <div>
-          <template is="dom-if" if="[[!_loading]]">
-            <div id="filter-results">
-              <h2>radium-filters demo</h2>
-              <div style="text-decoration:underline"><b>Selected Customer</b></div>
-              <div>{{_selectedCustomer}}</div>
-              <br/>
-              <div style="text-decoration:underline"><b>Selected Affiliates</b></div>
-              <template is="dom-repeat" items="{{_selectedAffiliates}}">
-                <div>{{item}}</div>
-              </template>
-              <br/>
-              <div style="text-decoration:underline"><b>Selected States</b></div>
-              <template is="dom-repeat" items="{{_selectedStates}}">
-                <div>{{item}}</div>
-              </template>
-              <br/>
-              <div style="text-decoration:underline"><b>Selected Sales Rep</b></div>
-              <div>{{_selectedRep}}</div>
-              <br/>
-              <div style="text-decoration:underline"><b>Selected Quarter</b></div>
-              <div>{{_selectedQtr}}</div>
-              <br/>
-              <div style="text-decoration:underline"><b>Ad-hoc Filter</b></div>
-              <div>{{_adhoc}}</div>
-            </div>
-          </template>
-        </div>
+<template is="dom-bind" id="app">
+  <radium-filter-querystring filters="[[_filters]]" terms="{{_terms}}"></radium-filter-querystring>
+  <div class="fit horizontal layout">
+    <div id="panelWrapper">
+      <radium-filter-panel id="filterpanel" filters="[[_filters]]" terms="{{_terms}}" loading="{{_loading}}"></radium-filter-panel>
+    </div>
+    <div class="flex">
+      <radium-filter-bar id="filterbar" label="Test" filters="[[_filters]]" terms="{{_terms}}" loading="{{_loading}}"></radium-filter-bar>
+      <div>
+        <template is="dom-if" if="[[!_loading]]">
+          <div id="filter-results">
+            <h2>radium-filters demo</h2>
+            <div style="text-decoration:underline"><b>Selected Customer</b></div>
+            <div>{{_selectedCustomer}}</div>
+            <br/>
+            <div style="text-decoration:underline"><b>Selected Affiliates</b></div>
+            <template is="dom-repeat" items="{{_selectedAffiliates}}">
+              <div>{{item}}</div>
+            </template>
+            <br/>
+            <div style="text-decoration:underline"><b>Selected States</b></div>
+            <template is="dom-repeat" items="{{_selectedStates}}">
+              <div>{{item}}</div>
+            </template>
+            <br/>
+            <div style="text-decoration:underline"><b>Selected Sales Rep</b></div>
+            <div>{{_selectedRep}}</div>
+            <br/>
+            <div style="text-decoration:underline"><b>Selected Quarter</b></div>
+            <div>{{_selectedQtr}}</div>
+            <br/>
+            <div style="text-decoration:underline"><b>Ad-hoc Filter</b></div>
+            <div>{{_adhoc}}</div>
+          </div>
+        </template>
       </div>
     </div>
-  </template>
-  <script>
-    // only overwrite to default hash if the has is unpopulated
-    if (window.location.hash.length === 0) {
-      window.location.hash = 'foo'; //right now, we only support hash routing query strings
+  </div>
+</template>
+<script>
+  // only overwrite to default hash if the has is unpopulated
+  if (window.location.hash.length === 0) {
+    window.location.hash = 'foo'; //right now, we only support hash routing query strings
+  }
+
+  var mockData = {}; // Populated further below.
+  function getNamesByValues(values) {
+    return new Promise(function(resolve) {
+      setTimeout(function() {
+        var filteredResults = mockData.names
+          .filter(function(result) {
+            return values.indexOf(result.value) != -1;
+          });
+        resolve(filteredResults);
+      }, 500);
+    });
+  }
+
+  function searchNames(searchText) {
+    return new Promise(function(resolve) {
+      setTimeout(function() {
+        var filteredResults = mockData.names
+          .filter(function(result) {
+            return result.label.toLowerCase().indexOf(searchText.toLowerCase()) != -1;
+          })
+          .sort(function(a, b) {
+            if (a.label < b.label) return -1;
+            if (a.label > b.label) return 1;
+            return 0;
+          });
+        resolve(filteredResults);
+      }, 500);
+    });
+  }
+
+  function personSource(query, done) {
+    if (Array.isArray(query)) {
+      getNamesByValues(query).then(done);
     }
-
-    var mockData = {}; // Populated further below.
-    function getNamesByValues(values) {
-      return new Promise(function(resolve) {
-        setTimeout(function() {
-          var filteredResults = mockData.names
-            .filter(function(result) {
-              return values.indexOf(result.value) != -1;
-            });
-          resolve(filteredResults);
-        }, 500);
-      });
+    else {
+      searchNames(query).then(done);
     }
+  }
 
-    function searchNames(searchText) {
-      return new Promise(function(resolve) {
-        setTimeout(function() {
-          var filteredResults = mockData.names
-            .filter(function(result) {
-              return result.label.toLowerCase().indexOf(searchText.toLowerCase()) != -1;
-            })
-            .sort(function(a, b) {
-              if (a.label < b.label) return -1;
-              if (a.label > b.label) return 1;
-              return 0;
-            });
-          resolve(filteredResults);
-        }, 500);
-      });
-    }
+  app._terms = [];
 
-    function personSource(query, done) {
-      if (Array.isArray(query)) {
-        getNamesByValues(query).then(done);
-      }
-      else {
-        searchNames(query).then(done);
-      }
-    }
+  app._loading = false;
+  app._selectedCustomer = '';
+  app._selectedAffiliates = [];
+  app._selectedStates = [];
+  app._selectedRep = '';
+  app._selectedQtr = '';
+  app._adhoc = '';
+  app._custom = '';
 
-    app._terms = [];
+  app.observers = [
+    '_termsChanged(_terms)'
+  ];
 
-    app._loading = false;
+  app._getTermLabel = function(term) {
+    return this.$.filterbar.getLabelForTerm(term);
+  };
+
+  app._termsChanged = function () {
     app._selectedCustomer = '';
     app._selectedAffiliates = [];
     app._selectedStates = [];
     app._selectedRep = '';
     app._selectedQtr = '';
     app._adhoc = '';
+    app._custom = '';
 
-    app.observers = [
-      '_termsChanged(_terms)'
-    ];
-
-    app._getTermLabel = function(term) {
-      return this.$.filterbar.getLabelForTerm(term);
-    };
-
-    app._termsChanged = function () {
-      app._selectedCustomer = '';
-      app._selectedAffiliates = [];
-      app._selectedStates = [];
-      app._selectedRep = '';
-      app._selectedQtr = '';
-      app._adhoc = '';
-
-      app._terms.forEach(function(term) {
-        var label = app._getTermLabel(term);
-        switch (term.key) {
-          case 'customer':
-            app._selectedCustomer = label;
-            break;
-          case 'affiliate':
-            app.push('_selectedAffiliates', label);
-            break;
-          case 'state':
-            app.push('_selectedStates', label);
-            break;
-          case 'rep':
-            app._selectedRep = label;
-            break;
-          case 'qtr':
-            app._selectedQtr = label;
-            break;
-          case 'adhoc':
-            app._adhoc = term.value;
-            break;
-        }
-      });
-    };
-
-    app._filters = [
-      {
-        type: 'autocomplete',
-        label: 'Customer',
-        key: 'customer',
-        options: {
-          source: personSource
-        }
-      },
-      {
-        type: 'autocompletelist',
-        label: 'Affiliate',
-        key: 'affiliate',
-        options: {
-          source: personSource
-        }
-      },
-      {
-        type: 'checkboxlist',
-        label: 'State',
-        key: 'state',
-        values: [
-          {label:'California', value:'California'},
-          {label:'Florida', value:'Florida'},
-          {label:'Nevada', value:'Nevada'},
-          {label:'New York', value:'New York'},
-          {label:'Texas', value:'Texas'}
-        ]
-      },
-      {
-        type: 'dropdownlist',
-        label: 'State',
-        key: 'state',
-        options: {
-          type: 'typeahead' // normally defaults to 'dropdown', other valid options are 'combobox'
-        },
-        values: [
-          {label:'California', value:'California'},
-          {label:'Florida', value:'Florida'},
-          {label:'Nevada', value:'Nevada'},
-          {label:'New York', value:'New York'},
-          {label:'Texas', value:'Texas'}
-        ]
-      },
-      {
-        type: 'dropdown',
-        label: 'Sales Rep',
-        key: 'rep',
-        values: [
-          {label:'John', value:'John'},
-          {label:'Bill', value:'Bill'},
-          {label:'Sharon', value:'Sharon'},
-          {label:'Mary', value:'Mary'},
-          {label:'George', value:'George'}
-        ]
-      },
-      {
-        type: 'dropdown',
-        label: 'Quarter',
-        key: 'qtr',
-        values: [
-          {label:'1st Quarter', value:1},
-          {label:'2nd Quarter', value:2},
-          {label:'3rd Quarter', value:3},
-          {label:'4th Quarter', value:4}
-        ]
-      },
-      {
-        type: 'input',
-        label: 'Ad-hoc Filter',
-        key: 'adhoc'
+    app._terms.forEach(function(term) {
+      var label = app._getTermLabel(term);
+      switch (term.key) {
+        case 'customer':
+          app._selectedCustomer = label;
+          break;
+        case 'affiliate':
+          app.push('_selectedAffiliates', label);
+          break;
+        case 'state':
+          app.push('_selectedStates', label);
+          break;
+        case 'rep':
+          app._selectedRep = label;
+          break;
+        case 'qtr':
+          app._selectedQtr = label;
+          break;
+        case 'adhoc':
+          app._adhoc = term.value;
+          break;
+        case 'custom':
+          app._custom = term.value;
+          break;
       }
-    ];
+    });
+  };
 
-    // Generated using: https://www.mockaroo.com/
-    mockData.names = [
-      {"label": "Emily", "value": "57a580b2-f6d9-4cd1-aec5-48a906d3b98b"},
-      {"label": "Dorothy", "value": "f761785f-c844-49f1-837d-4752e4876e5f"},
-      {"label": "Andrea", "value": "88f4128b-7999-43d1-91d8-16f69cf8efb7"},
-      {"label": "Douglas", "value": "ba40e126-c755-462d-bb2c-92047ae66c4b"},
-      {"label": "Anne", "value": "57df1b9c-6cce-4ea2-bd25-1cc006f2fa7c"},
-      {"label": "Jason", "value": "c35402c8-40ae-4504-9b72-a216f5bb2daf"},
-      {"label": "Louis", "value": "d1e8d52b-0473-4268-9f37-3b95fc5da513"},
-      {"label": "Keith", "value": "6a8c3907-72d4-4659-afdf-ee7b50f243d1"},
-      {"label": "Howard", "value": "21861986-38d6-4b6f-8234-beac02c2ea48"},
-      {"label": "Mary", "value": "a544b9ac-4dde-46c3-bfb1-48bd8cff9476"},
-      {"label": "Benjamin", "value": "3d19400c-5cf0-4b12-9b53-a87d8da2d13a"},
-      {"label": "Norma", "value": "65727787-4a9b-480c-a386-4a1eee9e0f86"},
-      {"label": "Judy", "value": "8e4ac742-9a5c-4e69-9830-237708bc9fa7"},
-      {"label": "Billy", "value": "7123d1cd-ac2b-4b87-8618-6f621c40499d"},
-      {"label": "David", "value": "6b167bab-6f56-4f48-8174-969ed9645e42"},
-      {"label": "Frank", "value": "77014339-33be-41fb-bb64-d33ea3350afd"},
-      {"label": "Joe", "value": "513ecf0c-530a-4459-a1a3-5e589a254217"},
-      {"label": "Heather", "value": "e609b23a-b266-4397-8a7c-04a634cad004"},
-      {"label": "Irene", "value": "ff5d7175-28f9-49ab-a879-76911e395d2a"},
-      {"label": "Andrew", "value": "71039dd4-127a-493d-a6d3-0aae79bc858d"},
-      {"label": "Frances", "value": "7bb5c895-afec-454e-8437-22ca0d8dc8a1"},
-      {"label": "Kathryn", "value": "8fbeb965-0f94-41bd-9afa-e683a0593814"},
-      {"label": "Laura", "value": "638df165-91b2-4e4c-93ef-dd2e7005b032"},
-      {"label": "Nicole", "value": "972ae8b2-ad4d-4b42-a091-623c2f27c83e"},
-      {"label": "Russell", "value": "2716524b-fbea-484b-949e-fb5abfe0c7ee"},
-      {"label": "Paula", "value": "bc66f07e-da68-46d5-9d93-0e401eea110b"},
-      {"label": "Joseph", "value": "5c533f1f-2553-43b5-8e29-59adea47c4d2"},
-      {"label": "Julie", "value": "bfbad71c-648f-4f0d-b530-dca97780310c"},
-      {"label": "Brian", "value": "7d0accef-91a9-4867-bb1c-2af468a5331a"},
-      {"label": "Juan", "value": "cdab9644-c85e-42e1-b4fa-ce64ccfe2cd2"},
-      {"label": "Sean", "value": "18b59c63-08b7-4375-93b9-89ad162e8ab2"},
-      {"label": "Phillip", "value": "d4aa1804-0db8-4b14-8087-7cc2b4b7162f"},
-      {"label": "Larry", "value": "6195e097-087e-4be7-967e-bf6610cc23f1"},
-      {"label": "Christine", "value": "597e31bc-34a6-4c61-8268-83bc0912f952"},
-      {"label": "Albert", "value": "23062d3b-3982-4393-bfd9-aab254913aa4"},
-      {"label": "Melissa", "value": "ff77734e-c7dc-45be-b6aa-8beb3d856a4a"},
-      {"label": "Donald", "value": "d24649f2-bdb7-4688-93db-b63ffbb662ab"},
-      {"label": "Mildred", "value": "00622c8d-de37-499e-af79-3bbd6387c70e"},
-      {"label": "Catherine", "value": "080afb7a-ddd9-4df6-94ed-c96b3bbd49b3"},
-      {"label": "Jean", "value": "ab943139-2e8d-41e9-a3d4-b81105d58754"},
-      {"label": "Philip", "value": "0dae47dc-587a-4e43-8871-e88a1f80ca9e"},
-      {"label": "Nancy", "value": "891c365c-4922-4f60-8107-41108bd56d97"},
-      {"label": "Stephanie", "value": "f3b99726-d871-4fa1-99a7-409a18ffeb27"},
-      {"label": "Michelle", "value": "a4acd230-afe7-4139-88c5-71dc1fca9c01"},
-      {"label": "Carlos", "value": "de6dff42-6b95-43d1-a183-9abc93290339"},
-      {"label": "Wanda", "value": "656db87a-4a99-495f-a355-f604a8b7bdcf"},
-      {"label": "Christopher", "value": "7b31f5b9-8fd8-4ff6-822d-141d9514fb67"},
-      {"label": "Jose", "value": "099277a7-41f4-48b6-81ce-7953aa5851fd"},
-      {"label": "Ronald", "value": "8b95e1f0-7608-4550-b672-625228809ac8"},
-      {"label": "Wayne", "value": "4af97918-de16-416f-8944-e05a7b2c5cf4"},
-      {"label": "Scott", "value": "d74fe35b-3297-42f8-9cb4-755a78929a6e"},
-      {"label": "Shawn", "value": "e11dd414-4cb9-439e-817c-263d05b5d64c"},
-      {"label": "Tina", "value": "ff66f92c-a62d-432a-850f-73f0f1d723b1"},
-      {"label": "Doris", "value": "f2e05adb-566e-48e4-b113-aeda9fa0a9de"},
-      {"label": "Ernest", "value": "0b2f31f5-deec-4c74-9380-128233dcea86"},
-      {"label": "Christina", "value": "56fbdb3f-b2b0-4147-846c-11a21e009a89"},
-      {"label": "Sandra", "value": "c768aea1-f1ba-4d95-9b9e-19ce2220ae08"},
-      {"label": "Virginia", "value": "466c1653-e727-4df5-b32d-b012d171ebed"},
-      {"label": "Beverly", "value": "be82c483-06f0-4598-8398-31e5dc151059"},
-      {"label": "Teresa", "value": "192e3157-d680-4f33-a1b6-e351019f804c"},
-      {"label": "Jerry", "value": "d4696f9d-531f-49c9-bda1-a6b924d94587"},
-      {"label": "Ryan", "value": "d04f36d0-be25-4ea9-9d6c-a98ec840e286"},
-      {"label": "Phyllis", "value": "d826e349-57d9-4e0c-8f71-9f29fb47b605"},
-      {"label": "Justin", "value": "223b58ba-507f-41a8-b29d-edbb644d2fec"},
-      {"label": "Shirley", "value": "ad969c67-36d2-4b95-bb30-9541aa225714"},
-      {"label": "Martha", "value": "c9556b7f-ec17-4fd1-9e9c-6f5d4d138714"},
-      {"label": "James", "value": "a84c247c-b013-4a51-903c-24eb55fc3b88"},
-      {"label": "Diana", "value": "7437a140-c1d5-4fd4-8b85-0dc5606b101a"},
-      {"label": "Marilyn", "value": "3a9a70d9-479a-4a2c-9701-55af53da4371"},
-      {"label": "Alan", "value": "8d762a2c-e8b6-4d78-8994-220af01af374"},
-      {"label": "Bruce", "value": "a91d5f0c-6dd5-44d2-9de9-d9fd59e2cdd4"},
-      {"label": "William", "value": "b5f1b4ee-afb3-4aeb-9b9c-412438c9aca2"},
-      {"label": "Carol", "value": "21bc88a8-3409-4fe1-ae90-42106a2fb6f1"},
-      {"label": "Stephen", "value": "db62f4e1-ec16-4ac4-9320-cda4762cca13"},
-      {"label": "Jonathan", "value": "780c2069-0540-4125-a1c4-3db3b5354241"},
-      {"label": "Denise", "value": "8333363d-776c-4144-9018-8ed77d3862b3"},
-      {"label": "Margaret", "value": "1a2ab255-f398-4a56-b3fc-301ee7f9e81b"},
-      {"label": "Harold", "value": "f7c3defe-f261-4611-bf49-ef66bafa57ac"},
-      {"label": "Gregory", "value": "84665604-ced9-4f85-8613-680da0a91fd8"},
-      {"label": "Janice", "value": "c4f53943-9d07-4753-b25d-120a8b3cd355"},
-      {"label": "Thomas", "value": "cb98a6b5-6e5e-4eef-8bf9-9dcd4e9b0433"},
-      {"label": "Ann", "value": "f9ea5209-16dc-4094-b0f4-17fdfea1e367"},
-      {"label": "Janet", "value": "f280393a-f27d-40eb-ae20-5c1464ba768e"},
-      {"label": "Theresa", "value": "cd78eceb-e2f8-4b4e-b3de-8122c3f510c0"},
-      {"label": "Todd", "value": "349a7123-a547-45d8-a0fb-e885457a31bb"},
-      {"label": "Roy", "value": "cbb26acf-ff64-4e69-a593-a269c3baa79e"},
-      {"label": "Daniel", "value": "4d75cb6a-3679-40e5-b14e-98677e46a53b"},
-      {"label": "Susan", "value": "b0c663cc-4797-4c31-b9d6-40703b422309"},
-      {"label": "Kevin", "value": "9c3a01c0-b2d4-4587-8c0c-5fa6f975dee5"},
-      {"label": "Jeremy", "value": "8f99995d-1d28-4d5d-823d-5c7fc947c169"},
-      {"label": "Patricia", "value": "adac70b7-9e04-499c-a855-afcb3b855b85"},
-      {"label": "Jane", "value": "a02563dd-b2d2-4ac2-a2fe-932c20441dbd"},
-      {"label": "Amy", "value": "faa2fdd5-3638-4ec1-bb6f-6cb0540d9421"},
-      {"label": "Dennis", "value": "63557d86-f979-46b9-aaa3-3e989e752c1c"},
-      {"label": "Sharon", "value": "0bc0f143-5ef8-41a1-b892-4fc9f8c97d24"},
-      {"label": "Diane", "value": "ba8b7a80-b030-43a5-a314-6220ebea6cac"},
-      {"label": "Brandon", "value": "0ac34762-1746-4dc0-b432-abdadbeaac2e"},
-      {"label": "Charles", "value": "2c89529d-50a7-4483-8093-ebca5c4ce065"},
-      {"label": "Cynthia", "value": "254cb58a-7234-4c34-b629-c99fa820d2dc"},
-      {"label": "Eric", "value": "815bedfa-e376-42af-a1ed-afb02d10410a"},
-      {"label": "Kelly", "value": "d7b24e84-269f-4821-92a6-8790281537b5"},
-      {"label": "Sarah", "value": "d34823d6-9b39-469a-bfc5-5670d0e3675f"},
-      {"label": "Rachel", "value": "71aed90e-90eb-4394-bdec-d9ac89ac3c82"},
-      {"label": "Evelyn", "value": "b332685c-16ca-482f-bd66-39a15bdf9212"},
-      {"label": "Willie", "value": "22ca143b-a28a-4c3e-95fa-b150c516c433"},
-      {"label": "Carl", "value": "f4649f48-f009-4c28-a3b2-0839df236080"},
-      {"label": "Pamela", "value": "318573d2-c315-49bd-902e-acced741d1de"},
-      {"label": "Gerald", "value": "162d3fec-76aa-48fd-8712-84a18c603867"},
-      {"label": "Betty", "value": "603ffdc2-02c5-4903-b0e6-5a7f0ec99215"},
-      {"label": "Peter", "value": "e4e1fa84-0be3-4ec5-a1cc-e9648b285951"},
-      {"label": "Kenneth", "value": "44553d7b-b7d5-433f-b920-a601f9e59a68"},
-      {"label": "Paul", "value": "b5bf6bbd-c4eb-4291-bddf-224d8ca73fd2"},
-      {"label": "Joan", "value": "7f1d9ddf-ed41-4e24-ad00-14f25dc9fc59"},
-      {"label": "Ruby", "value": "754d2032-13af-44cb-93a3-8244059ed1fe"},
-      {"label": "Marie", "value": "c93b2cff-6ae0-4f0b-a0cd-987a12679eed"},
-      {"label": "Jesse", "value": "2f9b1619-e76c-4027-811e-dce1fe83d30a"},
-      {"label": "George", "value": "5c4b0bbd-c31a-452a-93bd-d2efff972e42"},
-      {"label": "Jack", "value": "8232b1f1-fa32-4c7f-bdc8-11128d6f0c36"},
-      {"label": "Karen", "value": "90a2eba7-314a-482e-bdb6-32897c36d8db"},
-      {"label": "Louise", "value": "00a5e002-f6a8-479e-8abf-bc086134f7bd"},
-      {"label": "Jeffrey", "value": "4bd7997b-ab19-46c3-8afe-b261e55e6a50"},
-      {"label": "Anthony", "value": "f757ee6f-4848-41ae-8008-96fc67941ad7"},
-      {"label": "Jimmy", "value": "3267f3db-bc47-45b8-a205-f62303511de2"},
-      {"label": "Chris", "value": "2dcc947d-251f-484a-890b-3b75084531f0"},
-      {"label": "Carolyn", "value": "34348ee9-79b1-4b46-b22d-59e385e82b26"},
-      {"label": "Lisa", "value": "6317d5a7-a732-4edc-a762-10435eb3a0ad"},
-      {"label": "Angela", "value": "085df779-b966-4661-b71e-eee883d14b1e"},
-      {"label": "Richard", "value": "7b1406f2-9665-4065-9f4c-236b7e35926f"},
-      {"label": "Ashley", "value": "dd3da048-9df4-4ad7-97f1-8b9ca07f54f7"},
-      {"label": "Joshua", "value": "4fa6f78d-7bd9-4b4d-9fe6-4a20420ca311"},
-      {"label": "Elizabeth", "value": "9da14a77-4cc8-4e90-9dda-f3c8e2f33d7b"},
-      {"label": "Samuel", "value": "bf48d684-35b6-4928-8938-c8a9c13cc0aa"},
-      {"label": "Amanda", "value": "383308fa-4d40-45b8-b3ee-b6f14aec247c"},
-      {"label": "Henry", "value": "66f61672-7bbc-4b33-8e53-0cff5f319037"},
-      {"label": "Linda", "value": "122395ae-6895-4f9a-9334-5ad53f8bc7de"},
-      {"label": "Steven", "value": "b2a2072f-cba8-4ec9-bfb2-6f015776f2a5"},
-      {"label": "Rebecca", "value": "fede80a2-991f-46cb-a2a5-752d93f7725d"},
-      {"label": "Ralph", "value": "d43c6412-2a52-4d6a-9724-c91b6ba89912"},
-      {"label": "Fred", "value": "aa77c0eb-d881-45b6-b860-0309a85bacae"},
-      {"label": "Jessica", "value": "90f1457f-043b-4a58-88fe-c636fa513752"},
-      {"label": "Judith", "value": "6a6074b9-8292-4835-aa85-7ead4f8578b1"},
-      {"label": "Harry", "value": "5212c40a-b351-41c8-a812-7daefbbf6ae0"},
-      {"label": "Robin", "value": "b379aee8-0dcf-40fe-b8c7-1d025ed636f2"},
-      {"label": "John", "value": "440d5e60-4d8e-47cd-b75a-11d80faa609e"},
-      {"label": "Mark", "value": "90130ee9-839d-4330-af8c-9ac36935f95d"},
-      {"label": "Antonio", "value": "8710ed8c-c492-4d2c-8008-a7aea2c0963b"},
-      {"label": "Anna", "value": "a62bf769-de0a-4c2a-8991-41260cda0e77"},
-      {"label": "Julia", "value": "ada7d943-573d-4de2-9291-d8f3cc48b0d4"},
-      {"label": "Robert", "value": "c1e23185-08f8-4334-ac50-1eb65f59f177"},
-      {"label": "Cheryl", "value": "1c786283-ea7c-4fc4-b2d7-6a927e9835f0"}
-    ];
-  </script>
+  app._filters = [
+    {
+      type: 'autocomplete',
+      label: 'Customer',
+      key: 'customer',
+      options: {
+        source: personSource
+      }
+    },
+    {
+      type: 'autocompletelist',
+      label: 'Affiliate',
+      key: 'affiliate',
+      options: {
+        source: personSource
+      }
+    },
+    {
+      type: 'checkboxlist',
+      label: 'State',
+      key: 'state',
+      values: [
+        {label:'California', value:'California'},
+        {label:'Florida', value:'Florida'},
+        {label:'Nevada', value:'Nevada'},
+        {label:'New York', value:'New York'},
+        {label:'Texas', value:'Texas'}
+      ]
+    },
+    {
+      type: 'dropdownlist',
+      label: 'State',
+      key: 'state',
+      options: {
+        type: 'typeahead' // normally defaults to 'dropdown', other valid options are 'combobox'
+      },
+      values: [
+        {label:'California', value:'California'},
+        {label:'Florida', value:'Florida'},
+        {label:'Nevada', value:'Nevada'},
+        {label:'New York', value:'New York'},
+        {label:'Texas', value:'Texas'}
+      ]
+    },
+    {
+      type: 'dropdown',
+      label: 'Sales Rep',
+      key: 'rep',
+      values: [
+        {label:'John', value:'John'},
+        {label:'Bill', value:'Bill'},
+        {label:'Sharon', value:'Sharon'},
+        {label:'Mary', value:'Mary'},
+        {label:'George', value:'George'}
+      ]
+    },
+    {
+      type: 'dropdown',
+      label: 'Quarter',
+      key: 'qtr',
+      values: [
+        {label:'1st Quarter', value:1},
+        {label:'2nd Quarter', value:2},
+        {label:'3rd Quarter', value:3},
+        {label:'4th Quarter', value:4}
+      ]
+    },
+    {
+      type: 'input',
+      label: 'Ad-hoc Filter',
+      key: 'adhoc'
+    },
+    {
+      type: 'custom',
+      tagName: 'paper-slider',
+      options: {
+        min: 0,
+        max: 100
+      },
+      label: 'Custom',
+      key: 'custom'
+    }
+  ];
+
+  // Generated using: https://www.mockaroo.com/
+  mockData.names = [
+    {"label": "Emily", "value": "57a580b2-f6d9-4cd1-aec5-48a906d3b98b"},
+    {"label": "Dorothy", "value": "f761785f-c844-49f1-837d-4752e4876e5f"},
+    {"label": "Andrea", "value": "88f4128b-7999-43d1-91d8-16f69cf8efb7"},
+    {"label": "Douglas", "value": "ba40e126-c755-462d-bb2c-92047ae66c4b"},
+    {"label": "Anne", "value": "57df1b9c-6cce-4ea2-bd25-1cc006f2fa7c"},
+    {"label": "Jason", "value": "c35402c8-40ae-4504-9b72-a216f5bb2daf"},
+    {"label": "Louis", "value": "d1e8d52b-0473-4268-9f37-3b95fc5da513"},
+    {"label": "Keith", "value": "6a8c3907-72d4-4659-afdf-ee7b50f243d1"},
+    {"label": "Howard", "value": "21861986-38d6-4b6f-8234-beac02c2ea48"},
+    {"label": "Mary", "value": "a544b9ac-4dde-46c3-bfb1-48bd8cff9476"},
+    {"label": "Benjamin", "value": "3d19400c-5cf0-4b12-9b53-a87d8da2d13a"},
+    {"label": "Norma", "value": "65727787-4a9b-480c-a386-4a1eee9e0f86"},
+    {"label": "Judy", "value": "8e4ac742-9a5c-4e69-9830-237708bc9fa7"},
+    {"label": "Billy", "value": "7123d1cd-ac2b-4b87-8618-6f621c40499d"},
+    {"label": "David", "value": "6b167bab-6f56-4f48-8174-969ed9645e42"},
+    {"label": "Frank", "value": "77014339-33be-41fb-bb64-d33ea3350afd"},
+    {"label": "Joe", "value": "513ecf0c-530a-4459-a1a3-5e589a254217"},
+    {"label": "Heather", "value": "e609b23a-b266-4397-8a7c-04a634cad004"},
+    {"label": "Irene", "value": "ff5d7175-28f9-49ab-a879-76911e395d2a"},
+    {"label": "Andrew", "value": "71039dd4-127a-493d-a6d3-0aae79bc858d"},
+    {"label": "Frances", "value": "7bb5c895-afec-454e-8437-22ca0d8dc8a1"},
+    {"label": "Kathryn", "value": "8fbeb965-0f94-41bd-9afa-e683a0593814"},
+    {"label": "Laura", "value": "638df165-91b2-4e4c-93ef-dd2e7005b032"},
+    {"label": "Nicole", "value": "972ae8b2-ad4d-4b42-a091-623c2f27c83e"},
+    {"label": "Russell", "value": "2716524b-fbea-484b-949e-fb5abfe0c7ee"},
+    {"label": "Paula", "value": "bc66f07e-da68-46d5-9d93-0e401eea110b"},
+    {"label": "Joseph", "value": "5c533f1f-2553-43b5-8e29-59adea47c4d2"},
+    {"label": "Julie", "value": "bfbad71c-648f-4f0d-b530-dca97780310c"},
+    {"label": "Brian", "value": "7d0accef-91a9-4867-bb1c-2af468a5331a"},
+    {"label": "Juan", "value": "cdab9644-c85e-42e1-b4fa-ce64ccfe2cd2"},
+    {"label": "Sean", "value": "18b59c63-08b7-4375-93b9-89ad162e8ab2"},
+    {"label": "Phillip", "value": "d4aa1804-0db8-4b14-8087-7cc2b4b7162f"},
+    {"label": "Larry", "value": "6195e097-087e-4be7-967e-bf6610cc23f1"},
+    {"label": "Christine", "value": "597e31bc-34a6-4c61-8268-83bc0912f952"},
+    {"label": "Albert", "value": "23062d3b-3982-4393-bfd9-aab254913aa4"},
+    {"label": "Melissa", "value": "ff77734e-c7dc-45be-b6aa-8beb3d856a4a"},
+    {"label": "Donald", "value": "d24649f2-bdb7-4688-93db-b63ffbb662ab"},
+    {"label": "Mildred", "value": "00622c8d-de37-499e-af79-3bbd6387c70e"},
+    {"label": "Catherine", "value": "080afb7a-ddd9-4df6-94ed-c96b3bbd49b3"},
+    {"label": "Jean", "value": "ab943139-2e8d-41e9-a3d4-b81105d58754"},
+    {"label": "Philip", "value": "0dae47dc-587a-4e43-8871-e88a1f80ca9e"},
+    {"label": "Nancy", "value": "891c365c-4922-4f60-8107-41108bd56d97"},
+    {"label": "Stephanie", "value": "f3b99726-d871-4fa1-99a7-409a18ffeb27"},
+    {"label": "Michelle", "value": "a4acd230-afe7-4139-88c5-71dc1fca9c01"},
+    {"label": "Carlos", "value": "de6dff42-6b95-43d1-a183-9abc93290339"},
+    {"label": "Wanda", "value": "656db87a-4a99-495f-a355-f604a8b7bdcf"},
+    {"label": "Christopher", "value": "7b31f5b9-8fd8-4ff6-822d-141d9514fb67"},
+    {"label": "Jose", "value": "099277a7-41f4-48b6-81ce-7953aa5851fd"},
+    {"label": "Ronald", "value": "8b95e1f0-7608-4550-b672-625228809ac8"},
+    {"label": "Wayne", "value": "4af97918-de16-416f-8944-e05a7b2c5cf4"},
+    {"label": "Scott", "value": "d74fe35b-3297-42f8-9cb4-755a78929a6e"},
+    {"label": "Shawn", "value": "e11dd414-4cb9-439e-817c-263d05b5d64c"},
+    {"label": "Tina", "value": "ff66f92c-a62d-432a-850f-73f0f1d723b1"},
+    {"label": "Doris", "value": "f2e05adb-566e-48e4-b113-aeda9fa0a9de"},
+    {"label": "Ernest", "value": "0b2f31f5-deec-4c74-9380-128233dcea86"},
+    {"label": "Christina", "value": "56fbdb3f-b2b0-4147-846c-11a21e009a89"},
+    {"label": "Sandra", "value": "c768aea1-f1ba-4d95-9b9e-19ce2220ae08"},
+    {"label": "Virginia", "value": "466c1653-e727-4df5-b32d-b012d171ebed"},
+    {"label": "Beverly", "value": "be82c483-06f0-4598-8398-31e5dc151059"},
+    {"label": "Teresa", "value": "192e3157-d680-4f33-a1b6-e351019f804c"},
+    {"label": "Jerry", "value": "d4696f9d-531f-49c9-bda1-a6b924d94587"},
+    {"label": "Ryan", "value": "d04f36d0-be25-4ea9-9d6c-a98ec840e286"},
+    {"label": "Phyllis", "value": "d826e349-57d9-4e0c-8f71-9f29fb47b605"},
+    {"label": "Justin", "value": "223b58ba-507f-41a8-b29d-edbb644d2fec"},
+    {"label": "Shirley", "value": "ad969c67-36d2-4b95-bb30-9541aa225714"},
+    {"label": "Martha", "value": "c9556b7f-ec17-4fd1-9e9c-6f5d4d138714"},
+    {"label": "James", "value": "a84c247c-b013-4a51-903c-24eb55fc3b88"},
+    {"label": "Diana", "value": "7437a140-c1d5-4fd4-8b85-0dc5606b101a"},
+    {"label": "Marilyn", "value": "3a9a70d9-479a-4a2c-9701-55af53da4371"},
+    {"label": "Alan", "value": "8d762a2c-e8b6-4d78-8994-220af01af374"},
+    {"label": "Bruce", "value": "a91d5f0c-6dd5-44d2-9de9-d9fd59e2cdd4"},
+    {"label": "William", "value": "b5f1b4ee-afb3-4aeb-9b9c-412438c9aca2"},
+    {"label": "Carol", "value": "21bc88a8-3409-4fe1-ae90-42106a2fb6f1"},
+    {"label": "Stephen", "value": "db62f4e1-ec16-4ac4-9320-cda4762cca13"},
+    {"label": "Jonathan", "value": "780c2069-0540-4125-a1c4-3db3b5354241"},
+    {"label": "Denise", "value": "8333363d-776c-4144-9018-8ed77d3862b3"},
+    {"label": "Margaret", "value": "1a2ab255-f398-4a56-b3fc-301ee7f9e81b"},
+    {"label": "Harold", "value": "f7c3defe-f261-4611-bf49-ef66bafa57ac"},
+    {"label": "Gregory", "value": "84665604-ced9-4f85-8613-680da0a91fd8"},
+    {"label": "Janice", "value": "c4f53943-9d07-4753-b25d-120a8b3cd355"},
+    {"label": "Thomas", "value": "cb98a6b5-6e5e-4eef-8bf9-9dcd4e9b0433"},
+    {"label": "Ann", "value": "f9ea5209-16dc-4094-b0f4-17fdfea1e367"},
+    {"label": "Janet", "value": "f280393a-f27d-40eb-ae20-5c1464ba768e"},
+    {"label": "Theresa", "value": "cd78eceb-e2f8-4b4e-b3de-8122c3f510c0"},
+    {"label": "Todd", "value": "349a7123-a547-45d8-a0fb-e885457a31bb"},
+    {"label": "Roy", "value": "cbb26acf-ff64-4e69-a593-a269c3baa79e"},
+    {"label": "Daniel", "value": "4d75cb6a-3679-40e5-b14e-98677e46a53b"},
+    {"label": "Susan", "value": "b0c663cc-4797-4c31-b9d6-40703b422309"},
+    {"label": "Kevin", "value": "9c3a01c0-b2d4-4587-8c0c-5fa6f975dee5"},
+    {"label": "Jeremy", "value": "8f99995d-1d28-4d5d-823d-5c7fc947c169"},
+    {"label": "Patricia", "value": "adac70b7-9e04-499c-a855-afcb3b855b85"},
+    {"label": "Jane", "value": "a02563dd-b2d2-4ac2-a2fe-932c20441dbd"},
+    {"label": "Amy", "value": "faa2fdd5-3638-4ec1-bb6f-6cb0540d9421"},
+    {"label": "Dennis", "value": "63557d86-f979-46b9-aaa3-3e989e752c1c"},
+    {"label": "Sharon", "value": "0bc0f143-5ef8-41a1-b892-4fc9f8c97d24"},
+    {"label": "Diane", "value": "ba8b7a80-b030-43a5-a314-6220ebea6cac"},
+    {"label": "Brandon", "value": "0ac34762-1746-4dc0-b432-abdadbeaac2e"},
+    {"label": "Charles", "value": "2c89529d-50a7-4483-8093-ebca5c4ce065"},
+    {"label": "Cynthia", "value": "254cb58a-7234-4c34-b629-c99fa820d2dc"},
+    {"label": "Eric", "value": "815bedfa-e376-42af-a1ed-afb02d10410a"},
+    {"label": "Kelly", "value": "d7b24e84-269f-4821-92a6-8790281537b5"},
+    {"label": "Sarah", "value": "d34823d6-9b39-469a-bfc5-5670d0e3675f"},
+    {"label": "Rachel", "value": "71aed90e-90eb-4394-bdec-d9ac89ac3c82"},
+    {"label": "Evelyn", "value": "b332685c-16ca-482f-bd66-39a15bdf9212"},
+    {"label": "Willie", "value": "22ca143b-a28a-4c3e-95fa-b150c516c433"},
+    {"label": "Carl", "value": "f4649f48-f009-4c28-a3b2-0839df236080"},
+    {"label": "Pamela", "value": "318573d2-c315-49bd-902e-acced741d1de"},
+    {"label": "Gerald", "value": "162d3fec-76aa-48fd-8712-84a18c603867"},
+    {"label": "Betty", "value": "603ffdc2-02c5-4903-b0e6-5a7f0ec99215"},
+    {"label": "Peter", "value": "e4e1fa84-0be3-4ec5-a1cc-e9648b285951"},
+    {"label": "Kenneth", "value": "44553d7b-b7d5-433f-b920-a601f9e59a68"},
+    {"label": "Paul", "value": "b5bf6bbd-c4eb-4291-bddf-224d8ca73fd2"},
+    {"label": "Joan", "value": "7f1d9ddf-ed41-4e24-ad00-14f25dc9fc59"},
+    {"label": "Ruby", "value": "754d2032-13af-44cb-93a3-8244059ed1fe"},
+    {"label": "Marie", "value": "c93b2cff-6ae0-4f0b-a0cd-987a12679eed"},
+    {"label": "Jesse", "value": "2f9b1619-e76c-4027-811e-dce1fe83d30a"},
+    {"label": "George", "value": "5c4b0bbd-c31a-452a-93bd-d2efff972e42"},
+    {"label": "Jack", "value": "8232b1f1-fa32-4c7f-bdc8-11128d6f0c36"},
+    {"label": "Karen", "value": "90a2eba7-314a-482e-bdb6-32897c36d8db"},
+    {"label": "Louise", "value": "00a5e002-f6a8-479e-8abf-bc086134f7bd"},
+    {"label": "Jeffrey", "value": "4bd7997b-ab19-46c3-8afe-b261e55e6a50"},
+    {"label": "Anthony", "value": "f757ee6f-4848-41ae-8008-96fc67941ad7"},
+    {"label": "Jimmy", "value": "3267f3db-bc47-45b8-a205-f62303511de2"},
+    {"label": "Chris", "value": "2dcc947d-251f-484a-890b-3b75084531f0"},
+    {"label": "Carolyn", "value": "34348ee9-79b1-4b46-b22d-59e385e82b26"},
+    {"label": "Lisa", "value": "6317d5a7-a732-4edc-a762-10435eb3a0ad"},
+    {"label": "Angela", "value": "085df779-b966-4661-b71e-eee883d14b1e"},
+    {"label": "Richard", "value": "7b1406f2-9665-4065-9f4c-236b7e35926f"},
+    {"label": "Ashley", "value": "dd3da048-9df4-4ad7-97f1-8b9ca07f54f7"},
+    {"label": "Joshua", "value": "4fa6f78d-7bd9-4b4d-9fe6-4a20420ca311"},
+    {"label": "Elizabeth", "value": "9da14a77-4cc8-4e90-9dda-f3c8e2f33d7b"},
+    {"label": "Samuel", "value": "bf48d684-35b6-4928-8938-c8a9c13cc0aa"},
+    {"label": "Amanda", "value": "383308fa-4d40-45b8-b3ee-b6f14aec247c"},
+    {"label": "Henry", "value": "66f61672-7bbc-4b33-8e53-0cff5f319037"},
+    {"label": "Linda", "value": "122395ae-6895-4f9a-9334-5ad53f8bc7de"},
+    {"label": "Steven", "value": "b2a2072f-cba8-4ec9-bfb2-6f015776f2a5"},
+    {"label": "Rebecca", "value": "fede80a2-991f-46cb-a2a5-752d93f7725d"},
+    {"label": "Ralph", "value": "d43c6412-2a52-4d6a-9724-c91b6ba89912"},
+    {"label": "Fred", "value": "aa77c0eb-d881-45b6-b860-0309a85bacae"},
+    {"label": "Jessica", "value": "90f1457f-043b-4a58-88fe-c636fa513752"},
+    {"label": "Judith", "value": "6a6074b9-8292-4835-aa85-7ead4f8578b1"},
+    {"label": "Harry", "value": "5212c40a-b351-41c8-a812-7daefbbf6ae0"},
+    {"label": "Robin", "value": "b379aee8-0dcf-40fe-b8c7-1d025ed636f2"},
+    {"label": "John", "value": "440d5e60-4d8e-47cd-b75a-11d80faa609e"},
+    {"label": "Mark", "value": "90130ee9-839d-4330-af8c-9ac36935f95d"},
+    {"label": "Antonio", "value": "8710ed8c-c492-4d2c-8008-a7aea2c0963b"},
+    {"label": "Anna", "value": "a62bf769-de0a-4c2a-8991-41260cda0e77"},
+    {"label": "Julia", "value": "ada7d943-573d-4de2-9291-d8f3cc48b0d4"},
+    {"label": "Robert", "value": "c1e23185-08f8-4334-ac50-1eb65f59f177"},
+    {"label": "Cheryl", "value": "1c786283-ea7c-4fc4-b2d7-6a927e9835f0"}
+  ];
+</script>
 </body>
 </html>

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -16,6 +16,7 @@
    *  type: (string),
    *  label: (string),
    *  key: (string),
+   *  formatter: (?function),
    *  values: (Array<FilterValue>)
    * )} Filter
    */
@@ -183,6 +184,10 @@
      * @returns {number|string}
      */
     getLabelForTerm: function(term) {
+      var filter = this.getFilterForTerm(term);
+      if (filter && filter.formatter) {
+        return filter.formatter(term);
+      }
       var filterValue = this.getFilterValueForTerm(term);
       if (filterValue) {
         return filterValue.label;

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -141,7 +141,7 @@ Side Panel Polymer element for doing filters / faceted search.
 
           label.addEventListener('click', function(evt) {
             evt.stopPropagation();
-            
+
             collapse.toggle();
           });
 
@@ -170,6 +170,10 @@ Side Panel Polymer element for doing filters / faceted search.
 
             case 'dropdownlist':
               Polymer.dom(collapse).appendChild(this._createDropdownListControl(filter));
+              break;
+
+            case 'custom':
+              Polymer.dom(collapse).appendChild(this._createCustomControl(filter))
               break;
 
             default:
@@ -346,6 +350,14 @@ Side Panel Polymer element for doing filters / faceted search.
         return autocompleteList;
       },
 
+      _createCustomControl: function(filter) {
+        var custom = document.createElement(filter.tagName);
+        custom.setAttribute('data-filter-key', filter.key);
+        this._applyOptions(custom, filter.options || {});
+        custom.addEventListener(filter.changeEventName || 'change', this._customChanged.bind(this));
+        return custom;
+      },
+
       _createDropdownControl: function(filter) {
         var dropdown = document.createElement('radium-combo');
         dropdown.setAttribute('data-filter-key', filter.key);
@@ -398,7 +410,7 @@ Side Panel Polymer element for doing filters / faceted search.
             control.value = values;
             break;
           default:
-            console.warn("Unknown filter node: " + control.nodeName.toLowerCase());
+            control.value = values[0] || null;
             break;
         }
       },
@@ -424,7 +436,7 @@ Side Panel Polymer element for doing filters / faceted search.
             control.value = [];
             break;
           default:
-            console.warn("Unknown filter node: " + control.nodeName.toLowerCase());
+            control.value = null;
             break;
         }
       },
@@ -494,6 +506,17 @@ Side Panel Polymer element for doing filters / faceted search.
         var key = autocompleteList.getAttribute('data-filter-key');
         var value = e.detail.value;
         this.removeTerm(key, value);
+      },
+
+      _customChanged: function(e) {
+        var key = e.currentTarget.getAttribute('data-filter-key');
+        var value = e.currentTarget.value;
+        if (value && value !== null && value !== '') {
+          this.replaceTerm(key, value);
+        }
+        else {
+          this.removeTerm(key);
+        }
       },
 
       _dropdownChanged: function(e) {


### PR DESCRIPTION
* Added support for new `custom` filter type, accepts the following configuration:
    * `tagName` (string) - the tag to instantiate as the custom filter control element
    * `changeEventName` (optional string - defaults to “change”) - the event to listen for from the custom filter control element
    * `options` (object) - properties/attributes to apply to the custom filter control element
    * `formatter` (optional function) - called with the term, formats the value as it should appear in the filter bar chips.
* The custom filter control is expected to accept a String or null via its `value` property and render that value.
* Updated the demo to include an example of using a `<paper-slider>` as a custom control.
* Bumped version to `0.0.6`.