### PR TITLE
Reworked support for hidden controls.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,7 +42,7 @@
           <div id="filter-demo">
             <h2>radium-filters demo</h2>
 
-            <h3>Set type=hidden filter terms programmatically:</h3>
+            <h3>Set "hidden: true" filter terms programmatically:</h3>
             <button data-value="dev" on-tap="addDepartmentTerm">Add Development Department</button>
             <button data-value="qa" on-tap="addDepartmentTerm">Add Quality Assurance Department</button>
             <button data-value="sales" on-tap="addDepartmentTerm">Add Sales Department</button>
@@ -203,7 +203,7 @@
 
   app._filters = [
     {
-      type: 'hidden',
+      type: 'dropdown',
       label: 'Department',
       key: 'department',
       values: [
@@ -212,7 +212,8 @@
         {label:'Marketing', value:'mark'},
         {label:'Quality Assurance', value:'qa'},
         {label:'Sales', value:'sales'}
-      ]
+      ],
+      hidden: true
     },
     {
       type: 'autocomplete',

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -17,7 +17,8 @@
    *  label: (string),
    *  key: (string),
    *  formatter: (?function),
-   *  values: (Array<FilterValue>)
+   *  values: (Array<FilterValue>),
+   *  hidden: (?boolean)
    * )} Filter
    */
 

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -77,6 +77,10 @@ Side Panel Polymer element for doing filters / faceted search.
       --paper-spinner-layer-3-color: var(--radium-filter-loading-spinner-color, #0072BC);
       --paper-spinner-layer-4-color: var(--radium-filter-loading-spinner-color, #0072BC);
     }
+
+    .filter-row[hidden] {
+      display: none;
+    }
   </style>
   <template>
     <div class="filter-wrapper">
@@ -127,12 +131,11 @@ Side Panel Polymer element for doing filters / faceted search.
           filterContainer.removeChild(filterContainer.lastChild);
         }
         this.filters.forEach(function(filter, filterIndex) {
-          if (filter.type === 'hidden') {
-            return;
-          }
-          
           var filterRow = document.createElement('div');
           filterRow.className += 'filter-row';
+          if (filter.hidden) {
+            filterRow.setAttribute('hidden', '');
+          }
 
           var label = document.createElement('div');
           label.innerHTML = filter.label;


### PR DESCRIPTION
Instead of a using a `type` of `hidden`, filters now have an optional `hidden` property. If set to `true`, the controll will still be rendered to the filter panel, but it will be hidden via CSS via `display: none`. This way, filter controls that dynamically look up labels from values (ex. autocomplete / autocompletelist) will still do so when restoring values from the querystring.