### PR TITLE
Support for optional autocomplete suggestion menu specific labels.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -142,7 +142,7 @@ Dropdown list filter autocomplete component..
           <template is="dom-if" if="[[_hasMatches(_suggestions, _loading)]]">
             <template is="dom-repeat" items="[[_suggestions]]">
               <paper-item value="[[index]]" on-touchend="_onSuggestionItemTouchEnd" on-tap="_onSuggestionItemTap">
-                <span title$="[[item.label]]">[[item.label]]</span>
+                <span title$="[[_getSuggestionItemLabel(item)]]">[[_getSuggestionItemLabel(item)]]</span>
               </paper-item>
             </template>
           </template>
@@ -272,6 +272,10 @@ Dropdown list filter autocomplete component..
         } else {
           return 'arrow-drop-down';
         }
+      },
+
+      _getSuggestionItemLabel: function(item) {
+        return (item.suggestionLabel) ? item.suggestionLabel : item.label;
       },
 
       _setSuggestions: function(suggestions) {


### PR DESCRIPTION
* Added support for optional `suggestionLabel` property for suggestions in `<radium-filter-autocomplete>`.
    * Allows the `source` to optionally provide different labels for the suggestion dropdown options vs the final selected items for a `<radium-filter-autocomplete-list>`.
    * The new `suggestionLabel` precedence over `label` when supplied.