### PR TITLE
Added more reliable “blur” event to radium-filter-autocomplete.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -342,8 +342,11 @@ Dropdown list filter autocomplete component..
 
       _onDropdownIronOverlayClosed: function() {
         this._open = false;
-        if (this._isDirty && document.activeElement != this.$.input) {
-          this._clear();
+        if (document.activeElement !== this.$.input) {
+          if (this._isDirty) {
+            this._clear();
+          }
+          this.fire('blur');
         }
       },
 
@@ -359,8 +362,10 @@ Dropdown list filter autocomplete component..
       },
 
       _onInputBlur: function() {
-        if (this._isDirty && !this.$.dropdown.opened) {
-          this._clear();
+        if (!this.$.dropdown.opened) {
+          if (this._isDirty) {
+            this._clear();
+          }
           this.fire('blur');
         }
       },


### PR DESCRIPTION
<radium-filter-autocomplete> now dispatches a “blur” event when the dropdown is closed or the input loses focus (and the dropdown isn’t open).