### PR TITLE
Filter list items now render as chips, with optional support for prefix/suffix labels

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-filter-autocomplete-list.html
+++ b/radium-filter-autocomplete-list.html
@@ -11,39 +11,89 @@ Autocomplete list filter component.
 -->
 <dom-module id="radium-filter-autocomplete-list">
   <style is="custom-style">
-    .value-row {
+    #selectedChipsContainer {
+      margin: 0 -4px;
+    }
+
+    .chip {
+      background-color: #E0E0E0;
+      border-radius: 16px;
+      cursor: pointer;
+      height: 32px;
+      line-height: 20px;
       margin: 4px 0;
+      padding: 0 6px 0 12px;
+      text-transform: none;
+    }
+
+    .chip-content {
+      width: 100%;
+    }
+
+    .chip-label-container {
+      width: calc(100% - 20px);
+    }
+
+    .chip-label-prefix,
+    .chip-label,
+    .chip-label-suffix {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow-x: hidden;
+    }
+
+    .chip-label-prefix,
+    .chip-label-suffix {
+      color: #727272;
+      font-size: 9px;
+      line-height: 11px;
+    }
+
+    .chip-label {
+      font-size: 14px;
       line-height: 20px;
     }
 
-    .value-row .value-label {
-      display: inline-block;
-      width: calc(100% - 24px);
-      font-size: 14px;
-      font-weight: 400;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      vertical-align: middle;
+    .chip-label[has-prefix-or-suffix] {
+      font-size: 12px;
+      line-height: 14px;
     }
 
-    .value-row iron-icon {
-      width: 18px;
-      height: 18px;
-      vertical-align: middle;
+    .chip-cancel-icon {
+      color: #9E9E9E;
+      width: 20px;
+      height: 20px;
       cursor: pointer;
+    }
+
+    .chip:hover {
+      background-color: #616161;
+    }
+    .chip:hover .chip-label {
+      color: #ffffff;
+    }
+    .chip:hover .chip-label-prefix,
+    .chip:hover .chip-label-suffix {
+      color: #bdbdbd;
+    }
+    .chip:hover .chip-cancel-icon {
+      color: #ffffff;
     }
   </style>
   <template>
-    <div class="dropdown-list vertical layout">
-      <div class="vertical layout">
+    <div class="vertical layout">
+      <div id="selectedChipsContainer" class="vertical layout">
         <template is="dom-repeat" items="[[value]]">
-          <div class="value-row">
-            <div class="value-label" title="[[_getFilterValueLabelForValue(filterValues, item)]]">
-              [[_getFilterValueLabelForValue(filterValues, item)]]
+          <paper-button class="chip" on-tap="_chipTap">
+            <div class="chip-content horizontal layout center">
+              <div class="chip-label-container vertical layout">
+                <div class="chip-label-prefix" title$="[[_getFilterValuePrefixForValue(filterValues, item)]]">[[_getFilterValuePrefixForValue(filterValues, item)]]</div>
+                <div class="chip-label" has-prefix-or-suffix$="[[_hasFilterValuePrefixOrSuffixForValue(filterValues, item)]]" title$="[[_getFilterValueLabelForValue(filterValues, item)]]">[[_getFilterValueLabelForValue(filterValues, item)]]</div>
+                <div class="chip-label-suffix" title$="[[_getFilterValueSuffixForValue(filterValues, item)]]">[[_getFilterValueSuffixForValue(filterValues, item)]]</div>
+              </div>
+              <iron-icon class="chip-cancel-icon" icon="cancel"></iron-icon>
             </div>
-            <iron-icon icon="cancel" on-tap="_removeValueTap"></iron-icon>
-          </div>
+          </paper-button>
         </template>
       </div>
       <radium-filter-autocomplete id="autocomplete" no-label-float loading-message="[[loadingMessage]]" on-selected="_onAutocompleteSelected">
@@ -113,11 +163,29 @@ Autocomplete list filter component.
         }
       },
 
+      _getFilterValuePrefixForValue: function (filterValues, value) {
+        var filterValue = (filterValues || []).find(function (filterValue) {
+          return filterValue.value === value;
+        });
+        return (filterValue && filterValue.prefix) ? filterValue.prefix : null;
+      },
+
       _getFilterValueLabelForValue: function (filterValues, value) {
         var filterValue = (filterValues || []).find(function (filterValue) {
           return filterValue.value === value;
         });
         return (filterValue && filterValue.label) ? filterValue.label : value;
+      },
+
+      _getFilterValueSuffixForValue: function (filterValues, value) {
+        var filterValue = (filterValues || []).find(function (filterValue) {
+          return filterValue.value === value;
+        });
+        return (filterValue && filterValue.suffix) ? filterValue.suffix : null;
+      },
+
+      _hasFilterValuePrefixOrSuffixForValue: function(filterValues, value) {
+        return (this._getFilterValueSuffixForValue(filterValues, value) !== null);
       },
 
       _minLengthChanged: function(e) {
@@ -133,11 +201,11 @@ Autocomplete list filter component.
 
         if (suggestion.label && suggestion.value) {
           this.value = (this.value || []).concat(suggestion.value);
-          this.fire('value-added', { label: suggestion.label, value: suggestion.value, data: suggestion.data });
+          this.fire('value-added', { prefix: suggestion.prefix, label: suggestion.label, suffix: suggestion.suffix, value: suggestion.value, data: suggestion.data });
         }
       },
 
-      _removeValueTap: function (e) {
+      _chipTap: function (e) {
         e.stopPropagation();
 
         var valueToRemove = e.model.__data__.item;

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -47,7 +47,7 @@ Dropdown list filter autocomplete component..
       height: 20px;
       padding: 2px;
     }
-    
+
     paper-listbox {
       padding: 0;
     }
@@ -83,14 +83,29 @@ Dropdown list filter autocomplete component..
       height: 64px;
     }
 
-    paper-item span {
+    paper-item:hover {
+      background-color: #EEEEEE;
+    }
+
+    .list-item-label-container,
+    .list-item-prefix,
+    .list-item-label,
+    .list-item-suffix {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow-x: hidden;
     }
 
-    paper-item:hover {
-      background-color: #EEEEEE;
+    .list-item-prefix,
+    .list-item-suffix {
+      color: #727272;
+      font-size: 12px;
+      line-height: 16px;
+    }
+
+    .list-item-label {
+      font-size: 14px;
+      line-height: 20px;
     }
 
     paper-spinner {
@@ -142,7 +157,11 @@ Dropdown list filter autocomplete component..
           <template is="dom-if" if="[[_hasMatches(_suggestions, _loading)]]">
             <template is="dom-repeat" items="[[_suggestions]]">
               <paper-item value="[[index]]" on-touchend="_onSuggestionItemTouchEnd" on-tap="_onSuggestionItemTap">
-                <span title$="[[_getSuggestionItemLabel(item)]]">[[_getSuggestionItemLabel(item)]]</span>
+                <div class="list-item-label-container vertical layout">
+                  <div class="list-item-prefix" title$="[[_getSuggestionItemPrefix(item)]]">[[_getSuggestionItemPrefix(item)]]</div>
+                  <div class="list-item-label" title$="[[_getSuggestionItemLabel(item)]]">[[_getSuggestionItemLabel(item)]]</div>
+                  <div class="list-item-suffix" title$="[[_getSuggestionItemSuffix(item)]]">[[_getSuggestionItemSuffix(item)]]</div>
+                </div>
               </paper-item>
             </template>
           </template>
@@ -274,8 +293,16 @@ Dropdown list filter autocomplete component..
         }
       },
 
+      _getSuggestionItemPrefix: function(item) {
+        return (item.prefix) ? item.prefix : null;
+      },
+
       _getSuggestionItemLabel: function(item) {
         return (item.suggestionLabel) ? item.suggestionLabel : item.label;
+      },
+
+      _getSuggestionItemSuffix: function(item) {
+        return (item.suffix) ? item.suffix : null;
       },
 
       _setSuggestions: function(suggestions) {

--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -57,28 +57,55 @@ Header bar Polymer element for doing filters / faceted search.
       max-width: calc(100% - 20px);
       margin: 0;
     }
-    .filterbar paper-button .chip-label {
+    .filterbar paper-button .chip-label-container {
       font-size: 14px;
       font-weight: 400;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .filterbar paper-button .chip-label .filter-label {
+    .filterbar paper-button .chip-label-container .filter-label {
       font-weight: 500;
+      padding-right: 6px;
     }
-    .filterbar paper-button iron-icon {
+    .filterbar paper-button .chip-term-label-container .term-label-prefix,
+    .filterbar paper-button .chip-term-label-container .term-label,
+    .filterbar paper-button .chip-term-label-container .term-label-suffix {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow-x: hidden;
+    }
+    .filterbar paper-button .chip-term-label-container .term-label-prefix,
+    .filterbar paper-button .chip-term-label-container .term-label-suffix {
+      color: #727272;
+      font-size: 9px;
+      line-height: 11px;
+    }
+    .filterbar paper-button .chip-term-label-container .term-label {
+      font-size: 14px;
+      line-height: 20px;
+    }
+    .filterbar paper-button .chip-term-label-container .term-label[has-prefix-or-suffix] {
+      font-size: 12px;
+      line-height: 14px;
+    }
+    .filterbar paper-button .chip-cancel-icon {
       color: #9E9E9E;
       width: 20px;
       height: 20px;
       margin-top: -2px;
       line-height: 14px;
     }
+
     .filterbar paper-button:hover {
       color: #ffffff;
       background-color: #616161;
     }
-    .filterbar paper-button:hover iron-icon {
+    .filterbar paper-button:hover .chip-term-label-container .term-label-prefix,
+    .filterbar paper-button:hover .chip-term-label-container .term-label-suffix {
+      color: #bdbdbd;
+    }
+    .filterbar paper-button:hover .chip-cancel-icon {
       color: #ffffff;
     }
 
@@ -118,13 +145,15 @@ Header bar Polymer element for doing filters / faceted search.
           <div class="horizontal layout wrap">
             <template is="dom-repeat" items="[[_getChipsForFiltersAndTerms(filters, terms)]]">
               <paper-button data-term$="[[item]]" on-click="_termClicked">
-                <div class="chip-label-container">
-                  <span class="chip-label">
-                    <span class="filter-label" hidden$="[[hideFilterLabel]]">[[item.filterLabel]]:</span>
-                    <span class="term-label">[[item.label]]</span>
-                  </span>
+                <div class="chip-label-container horizontal layout center">
+                  <span class="filter-label" hidden$="[[hideFilterLabel]]">[[item.filterLabel]]:</span>
+                  <div class="chip-term-label-container vertical layout">
+                    <div class="term-label-prefix">[[item.prefix]]</div>
+                    <div class="term-label" has-prefix-or-suffix$="[[_hasPrefixOrSuffix(item)]]">[[item.label]]</div>
+                    <div class="term-label-suffix">[[item.suffix]]</div>
+                  </div>
                 </div>
-                <iron-icon icon="cancel"></iron-icon>
+                <iron-icon class="chip-cancel-icon" icon="cancel"></iron-icon>
               </paper-button>
             </template>
           </div>
@@ -186,22 +215,28 @@ Header bar Polymer element for doing filters / faceted search.
         return this.terms.map(function(term){
           return {
             filterLabel: this.getFilterLabelForTerm(term),
+            prefix: this.getPrefixForTerm(term),
             label: this.getLabelForTerm(term),
+            suffix: this.getSuffixForTerm(term),
             key: term.key,
             value: term.value
           }
         }.bind(this));
       },
 
+      _hasPrefixOrSuffix: function(item) {
+        return Boolean(item.prefix || item.suffix);
+      },
+
       _clearAllClicked: function(evt) {
         evt.stopPropagation();
-        
+
         this.removeAllTerms();
       },
 
       _termClicked: function(evt) {
         evt.stopPropagation();
-        
+
         var term = JSON.parse(evt.currentTarget.getAttribute('data-term'));
         this.removeTerm(term.key, term.value);
       }

--- a/radium-filter-behavior.html
+++ b/radium-filter-behavior.html
@@ -3,7 +3,9 @@
    * Filter value.
    *
    * @typedef {(
+   *  prefix: (?string)
    *  label: (string),
+   *  suffix: (?string)
    *  value: (number|string),
    *  data: (object)
    * )} FilterValue
@@ -67,7 +69,7 @@
      * @param {string} label
      * @param {number|string} value
      */
-    replaceFilterValue: function(key, label, value, data) {
+    replaceFilterValue: function(key, prefix, label, suffix, value, data) {
       var filter = this.filters.find(function(filter) {
         return filter.key === key;
       });
@@ -75,7 +77,9 @@
         filter.values = (filter.values || []).filter(function(filterValue) {
           return !(filterValue.value == value);
         }).concat( {
+          prefix: prefix,
           label: label,
+          suffix: suffix,
           value: value,
           data: data
         });
@@ -182,6 +186,20 @@
      * Gets the label that corresponds to the specified term (if available), or returns the term value.
      *
      * @param {FilterTerm} term
+     * @returns {number|string|null}
+     */
+    getPrefixForTerm: function(term) {
+      var filterValue = this.getFilterValueForTerm(term);
+      if (filterValue) {
+        return filterValue.prefix;
+      }
+      return null;
+    },
+
+    /**
+     * Gets the label that corresponds to the specified term (if available), or returns the term value.
+     *
+     * @param {FilterTerm} term
      * @returns {number|string}
      */
     getLabelForTerm: function(term) {
@@ -194,6 +212,20 @@
         return filterValue.label;
       }
       return term.value;
+    },
+
+    /**
+     * Gets the label that corresponds to the specified term (if available), or returns the term value.
+     *
+     * @param {FilterTerm} term
+     * @returns {number|string|null}
+     */
+    getSuffixForTerm: function(term) {
+      var filterValue = this.getFilterValueForTerm(term);
+      if (filterValue) {
+        return filterValue.suffix;
+      }
+      return null;
     },
 
     /**

--- a/radium-filter-dropdown-list.html
+++ b/radium-filter-dropdown-list.html
@@ -11,37 +11,51 @@ Dropdown list filter component.
 -->
 <dom-module id="radium-filter-dropdown-list">
   <style is="custom-style">
-    .value-row {
+    #selectedChipsContainer {
+      margin: 0 -4px;
+    }
+
+    .chip {
+      background-color: #E0E0E0;
+      border-radius: 16px;
+      cursor: pointer;
+      height: 32px;
+      line-height: 20px;
       margin: 4px 0;
+      padding: 0 6px 0 12px;
+      text-transform: none;
+    }
+
+    .chip-content {
+      width: 100%;
+    }
+
+    .chip-label {
+      width: calc(100% - 20px);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow-x: hidden;
+      font-size: 14px;
       line-height: 20px;
     }
 
-    .value-row .value-label {
-      display: inline-block;
-      width: calc(100% - 24px);
-      font-size: 14px;
-      font-weight: 400;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      vertical-align: middle;
-    }
-
-    .value-row iron-icon {
-      width: 18px;
-      height: 18px;
-      vertical-align: middle;
+    .chip-cancel-icon {
+      color: #9E9E9E;
+      width: 20px;
+      height: 20px;
       cursor: pointer;
     }
   </style>
   <template>
-    <div class="dropdown-list vertical layout">
-      <div class="vertical layout">
+    <div class="vertical layout">
+      <div id="selectedChipsContainer" class="vertical layout">
         <template is="dom-repeat" items="[[value]]">
-          <div class="value-row">
-            <div class="value-label" title="[[_getOptionLabelForValue(options, item)]]">[[_getOptionLabelForValue(options, item)]]</div>
-            <iron-icon icon="cancel" on-tap="_removeValueTap"></iron-icon>
-          </div>
+          <paper-button class="chip" on-tap="_chipTap">
+            <div class="chip-content horizontal layout center">
+              <div class="chip-label" title="[[_getOptionLabelForValue(options, item)]]">[[_getOptionLabelForValue(options, item)]]</div>
+              <iron-icon class="chip-cancel-icon" icon="cancel"></iron-icon>
+            </div>
+          </paper-button>
         </template>
       </div>
       <radium-combo id="combo" type="[[type]]" options="[[_getFilteredListOptions(options, value)]]" include-empty="false" no-label-float on-option-change="_optionChange"></radium-combo>
@@ -116,9 +130,9 @@ Dropdown list filter component.
         }
       },
 
-      _removeValueTap: function(e) {
+      _chipTap: function(e) {
         e.stopPropagation();
-        
+
         var valueToRemove = e.model.__data__.item;
 
         this.value = (this.value || []).filter(function(value) {

--- a/radium-filter-panel.html
+++ b/radium-filter-panel.html
@@ -258,14 +258,14 @@ Side Panel Polymer element for doing filters / faceted search.
                             });
                             if (suggestion) {
                               // Use the label/value returned as a suggestion as the new filter value.
-                              return {label: suggestion.label, value: suggestion.value, data: suggestion.data};
+                              return { prefix: suggestion.prefix, label: suggestion.label, suffix: suggestion.suffix, value: suggestion.value, data: suggestion.data };
                             }
                             else {
                               // No corresponding suggestion was returned, check if we already have the filter value.
                               var filterValue = this.getFilterValueForTerm(term);
                               if (!filterValue) {
                                 // Create a new filter value, using the value as the label.
-                                return {label: term.value, value: term.value, data: undefined};
+                                return { prefix: term.prefix, label: term.value, suffix: term.suffix, value: term.value, data: undefined };
                               }
                               // Use the existing filter value.
                               return filterValue;
@@ -486,10 +486,12 @@ Side Panel Polymer element for doing filters / faceted search.
       _autocompleteSelected: function(e) {
         var autocomplete = e.currentTarget;
         var key = autocomplete.getAttribute('data-filter-key');
+        var prefix = e.detail.prefix;
         var label = e.detail.label;
+        var suffix = e.detail.suffix;
         var value = e.detail.value;
         if (value) {
-          this.setFilterValues(key, [{ label: label, value: value }]);
+          this.setFilterValues(key, [{ prefix: prefix, label: label, suffix: suffix, value: value }]);
           this.replaceTerm(key, value);
         }
         else {
@@ -501,10 +503,12 @@ Side Panel Polymer element for doing filters / faceted search.
       _autocompleteListValueAdded: function(e) {
         var autocompleteList = e.currentTarget;
         var key = autocompleteList.getAttribute('data-filter-key');
+        var prefix = e.detail.prefix;
         var label = e.detail.label;
+        var suffix = e.detail.suffix;
         var value = e.detail.value;
         var data = e.detail.data;
-        this.replaceFilterValue(key, label, value, data);
+        this.replaceFilterValue(key, prefix, label, suffix, value, data);
         this.addTerm(key, value);
       },
 


### PR DESCRIPTION
* Autocomplete suggestions and filter bar chips now support optional “prefix” and “suffix” labels
    * If the `source` function for a `radium-filter-autocomplete` or `radium-filter-autocomplete-list` component returns values for the new optional `prefix` or `suffix` suggestion properties, these labels will be rendered in the suggestion menu and in the resulting filter bar chips.
* Selected items for list filters in the filter panel are now rendered as chips - this affects:
    * `radium-filter-autocomplete-list`
    * `radium-filter-dropdown-list`