### PR TITLE
Input height tweak for Internet Explorer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-filter-autocomplete.html
+++ b/radium-filter-autocomplete.html
@@ -25,6 +25,7 @@ Dropdown list filter autocomplete component..
       overflow: hidden;
       text-overflow: ellipsis;
       padding-right: 24px;
+      height: 24px;
     }
 
     #input[disabled] {


### PR DESCRIPTION
* Added explicit `height` for `input` to fix an issue where Internet Explorer defaulted to a smaller height and clipped the input text.