### PR TITLE
Layout tweak for Mozilla Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-filters",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Header bar and side panel Polymer elements for doing filters / faceted search",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-filter-bar.html
+++ b/radium-filter-bar.html
@@ -56,8 +56,10 @@ Header bar Polymer element for doing filters / faceted search.
       display: inline-flex;
       max-width: calc(100% - 20px);
       margin: 0;
+      vertical-align: middle;
     }
     .filterbar paper-button .chip-label-container {
+      margin-top: -2px;
       font-size: 14px;
       font-weight: 400;
       white-space: nowrap;


### PR DESCRIPTION
* Minor tweak to ensure the icon close button for a filter bar chip does not appear “shifted down” and out of vertical alignment with the filter bar chip’s label.